### PR TITLE
Add lyric, tie, print, ...

### DIFF
--- a/example/assets/musicXML.xml
+++ b/example/assets/musicXML.xml
@@ -59,7 +59,7 @@
     </part-list>
     <part id="P1">
         <measure width="492.75" number="1">
-            <print>
+            <print page-number="1">
                 <system-layout>
                     <system-margins>
                         <left-margin>3.00</left-margin>
@@ -84,7 +84,7 @@
                 </clef>
             </attributes>
             <note>
-                <rest/>
+                <rest />
                 <duration>6</duration>
                 <voice>1</voice>
                 <type>quarter</type>
@@ -104,11 +104,18 @@
                 <stem>down</stem>
                 <beam number="1">begin</beam>
                 <notations>
-                    <tuplet type="start" bracket="no"/>
+                    <tuplet type="start" bracket="no" />
                 </notations>
-                <lyric number="1">
+                <lyric number="1" name="verse1">
+                    <syllabic>single</syllabic>
+                    <text>1.</text>
+                    <elision> </elision>
                     <syllabic>begin</syllabic>
                     <text>Ma</text>
+                </lyric>
+                <lyric number="2" name="verse2">
+                    <syllabic>begin</syllabic>
+                    <text>Mo</text>
                 </lyric>
             </note>
             <note default-y="-20.00" default-x="237.10">
@@ -126,9 +133,13 @@
                 </time-modification>
                 <stem>down</stem>
                 <beam number="1">continue</beam>
-                <lyric number="1">
+                <lyric number="1" name="verse1">
                     <syllabic>end</syllabic>
                     <text>ny</text>
+                </lyric>
+                <lyric number="2" name="verse2">
+                    <syllabic>end</syllabic>
+                    <text>re ...</text>
                 </lyric>
             </note>
             <note default-y="-15.00" default-x="287.91">
@@ -146,9 +157,9 @@
                 <stem>down</stem>
                 <beam number="1">end</beam>
                 <notations>
-                    <tuplet type="stop"/>
+                    <tuplet type="stop" />
                 </notations>
-                <lyric number="1">
+                <lyric number="1" name="verse1">
                     <syllabic>single</syllabic>
                     <text>a</text>
                 </lyric>
@@ -168,9 +179,9 @@
                 <stem>down</stem>
                 <beam number="1">begin</beam>
                 <notations>
-                    <tuplet type="start" bracket="no"/>
+                    <tuplet type="start" bracket="no" />
                 </notations>
-                <lyric number="1">
+                <lyric number="1" name="verse1">
                     <syllabic>single</syllabic>
                     <text>tear</text>
                 </lyric>
@@ -189,7 +200,7 @@
                 </time-modification>
                 <stem>down</stem>
                 <beam number="1">continue</beam>
-                <lyric number="1">
+                <lyric number="1" name="verse1">
                     <syllabic>single</syllabic>
                     <text>has</text>
                 </lyric>
@@ -210,9 +221,9 @@
                 <stem>down</stem>
                 <beam number="1">end</beam>
                 <notations>
-                    <tuplet type="stop"/>
+                    <tuplet type="stop" />
                 </notations>
-                <lyric number="1">
+                <lyric number="1" name="verse1">
                     <syllabic>single</syllabic>
                     <text>to</text>
                 </lyric>
@@ -234,7 +245,7 @@
                 <voice>1</voice>
                 <type>half</type>
                 <stem>up</stem>
-                <lyric number="1">
+                <lyric number="1" name="verse1">
                     <syllabic>single</syllabic>
                     <text>fall</text>
                 </lyric>
@@ -249,7 +260,7 @@
                 <type>eighth</type>
                 <stem>up</stem>
                 <beam number="1">begin</beam>
-                <lyric number="1">
+                <lyric number="1" name="verse1">
                     <syllabic>single</syllabic>
                     <text>but</text>
                 </lyric>
@@ -264,7 +275,7 @@
                 <type>eighth</type>
                 <stem>up</stem>
                 <beam number="1">end</beam>
-                <lyric number="1">
+                <lyric number="1" name="verse1">
                     <syllabic>single</syllabic>
                     <text>it's</text>
                 </lyric>
@@ -287,7 +298,7 @@
                 <voice>1</voice>
                 <type>half</type>
                 <stem>up</stem>
-                <lyric number="1">
+                <lyric number="1" name="verse1">
                     <syllabic>single</syllabic>
                     <text>all</text>
                 </lyric>
@@ -308,7 +319,7 @@
                 <type>eighth</type>
                 <stem>up</stem>
                 <beam number="1">begin</beam>
-                <lyric number="1">
+                <lyric number="1" name="verse1">
                     <syllabic>single</syllabic>
                     <text>in</text>
                 </lyric>
@@ -323,7 +334,7 @@
                 <type>eighth</type>
                 <stem>up</stem>
                 <beam number="1">end</beam>
-                <lyric number="1">
+                <lyric number="1" name="verse1">
                     <syllabic>single</syllabic>
                     <text>the</text>
                 </lyric>
@@ -344,9 +355,9 @@
                 <duration>18</duration>
                 <voice>1</voice>
                 <type>half</type>
-                <dot/>
+                <dot />
                 <stem>up</stem>
-                <lyric number="1">
+                <lyric number="1" name="verse1">
                     <syllabic>single</syllabic>
                     <text>game</text>
                 </lyric>
@@ -363,7 +374,7 @@
                 </system-layout>
             </print>
             <note>
-                <rest/>
+                <rest />
                 <duration>6</duration>
                 <voice>1</voice>
                 <type>quarter</type>
@@ -383,9 +394,9 @@
                 <stem>down</stem>
                 <beam number="1">begin</beam>
                 <notations>
-                    <tuplet type="start" bracket="no"/>
+                    <tuplet type="start" bracket="no" />
                 </notations>
-                <lyric number="1">
+                <lyric number="1" name="verse1">
                     <syllabic>single</syllabic>
                     <text>All</text>
                 </lyric>
@@ -405,7 +416,7 @@
                 </time-modification>
                 <stem>down</stem>
                 <beam number="1">continue</beam>
-                <lyric number="1">
+                <lyric number="1" name="verse1">
                     <syllabic>single</syllabic>
                     <text>in</text>
                 </lyric>
@@ -425,9 +436,9 @@
                 <stem>down</stem>
                 <beam number="1">end</beam>
                 <notations>
-                    <tuplet type="stop"/>
+                    <tuplet type="stop" />
                 </notations>
-                <lyric number="1">
+                <lyric number="1" name="verse1">
                     <syllabic>single</syllabic>
                     <text>the</text>
                 </lyric>
@@ -454,9 +465,9 @@
                 <stem>down</stem>
                 <beam number="1">begin</beam>
                 <notations>
-                    <tuplet type="start" bracket="no"/>
+                    <tuplet type="start" bracket="no" />
                 </notations>
-                <lyric number="1">
+                <lyric number="1" name="verse1">
                     <syllabic>begin</syllabic>
                     <text>won</text>
                 </lyric>
@@ -475,7 +486,7 @@
                 </time-modification>
                 <stem>down</stem>
                 <beam number="1">continue</beam>
-                <lyric number="1">
+                <lyric number="1" name="verse1">
                     <syllabic>middle</syllabic>
                     <text>der</text>
                 </lyric>
@@ -496,9 +507,9 @@
                 <stem>down</stem>
                 <beam number="1">end</beam>
                 <notations>
-                    <tuplet type="stop"/>
+                    <tuplet type="stop" />
                 </notations>
-                <lyric number="1">
+                <lyric number="1" name="verse1">
                     <syllabic>end</syllabic>
                     <text>ful</text>
                 </lyric>
@@ -520,7 +531,7 @@
                 <voice>1</voice>
                 <type>half</type>
                 <stem>up</stem>
-                <lyric number="1">
+                <lyric number="1" name="verse1">
                     <syllabic>single</syllabic>
                     <text>game</text>
                 </lyric>
@@ -535,7 +546,7 @@
                 <type>eighth</type>
                 <stem>up</stem>
                 <beam number="1">begin</beam>
-                <lyric number="1">
+                <lyric number="1" name="verse1">
                     <syllabic>single</syllabic>
                     <text>that</text>
                 </lyric>
@@ -550,7 +561,7 @@
                 <type>eighth</type>
                 <stem>up</stem>
                 <beam number="1">end</beam>
-                <lyric number="1">
+                <lyric number="1" name="verse1">
                     <syllabic>single</syllabic>
                     <text>we</text>
                 </lyric>
@@ -573,7 +584,7 @@
                 <voice>1</voice>
                 <type>half</type>
                 <stem>down</stem>
-                <lyric number="1">
+                <lyric number="1" name="verse1">
                     <syllabic>single</syllabic>
                     <text>know</text>
                 </lyric>
@@ -587,7 +598,7 @@
                 <voice>1</voice>
                 <type>quarter</type>
                 <stem>up</stem>
-                <lyric number="1">
+                <lyric number="1" name="verse1">
                     <syllabic>single</syllabic>
                     <text>as</text>
                 </lyric>
@@ -606,15 +617,15 @@
                     <octave>4</octave>
                 </pitch>
                 <duration>18</duration>
-                <tie type="start"/>
+                <tie type="start" />
                 <voice>1</voice>
                 <type>half</type>
-                <dot/>
+                <dot />
                 <stem>up</stem>
                 <notations>
-                    <tied type="start"/>
+                    <tied type="start" />
                 </notations>
-                <lyric number="1">
+                <lyric number="1" name="verse1">
                     <syllabic>single</syllabic>
                     <text>love.</text>
                 </lyric>
@@ -636,16 +647,16 @@
                     <octave>4</octave>
                 </pitch>
                 <duration>6</duration>
-                <tie type="stop"/>
+                <tie type="stop" />
                 <voice>1</voice>
                 <type>quarter</type>
                 <stem>up</stem>
                 <notations>
-                    <tied type="stop"/>
+                    <tied type="stop" />
                 </notations>
             </note>
             <note>
-                <rest/>
+                <rest />
                 <duration>6</duration>
                 <voice>1</voice>
                 <type>quarter</type>
@@ -660,7 +671,7 @@
                 <type>eighth</type>
                 <stem>up</stem>
                 <beam number="1">begin</beam>
-                <lyric number="1">
+                <lyric number="1" name="verse1">
                     <syllabic>single</syllabic>
                     <text>You</text>
                 </lyric>
@@ -676,7 +687,7 @@
                 <type>eighth</type>
                 <stem>up</stem>
                 <beam number="1">end</beam>
-                <lyric number="1">
+                <lyric number="1" name="verse1">
                     <syllabic>single</syllabic>
                     <text>have</text>
                 </lyric>
@@ -692,7 +703,7 @@
                 <voice>1</voice>
                 <type>half</type>
                 <stem>down</stem>
-                <lyric number="1">
+                <lyric number="1" name="verse1">
                     <syllabic>single</syllabic>
                     <text>words</text>
                 </lyric>
@@ -706,7 +717,7 @@
                 <voice>1</voice>
                 <type>quarter</type>
                 <stem>up</stem>
-                <lyric number="1">
+                <lyric number="1" name="verse1">
                     <syllabic>single</syllabic>
                     <text>with</text>
                 </lyric>
@@ -728,7 +739,7 @@
                 <voice>1</voice>
                 <type>half</type>
                 <stem>up</stem>
-                <lyric number="1">
+                <lyric number="1" name="verse1">
                     <syllabic>single</syllabic>
                     <text>him</text>
                 </lyric>
@@ -743,7 +754,7 @@
                 <type>eighth</type>
                 <stem>up</stem>
                 <beam number="1">begin</beam>
-                <lyric number="1">
+                <lyric number="1" name="verse1">
                     <syllabic>single</syllabic>
                     <text>and</text>
                 </lyric>
@@ -759,7 +770,7 @@
                 <type>eighth</type>
                 <stem>up</stem>
                 <beam number="1">end</beam>
-                <lyric number="1">
+                <lyric number="1" name="verse1">
                     <syllabic>single</syllabic>
                     <text>your</text>
                 </lyric>
@@ -778,14 +789,14 @@
                     <octave>5</octave>
                 </pitch>
                 <duration>6</duration>
-                <tie type="start"/>
+                <tie type="start" />
                 <voice>1</voice>
                 <type>quarter</type>
                 <stem>down</stem>
                 <notations>
-                    <tied type="start"/>
+                    <tied type="start" />
                 </notations>
-                <lyric number="1">
+                <lyric number="1" name="verse1">
                     <syllabic>begin</syllabic>
                     <text>fu</text>
                 </lyric>
@@ -796,13 +807,13 @@
                     <octave>5</octave>
                 </pitch>
                 <duration>3</duration>
-                <tie type="stop"/>
+                <tie type="stop" />
                 <voice>1</voice>
                 <type>eighth</type>
                 <stem>down</stem>
                 <beam number="1">begin</beam>
                 <notations>
-                    <tied type="stop"/>
+                    <tied type="stop" />
                 </notations>
             </note>
             <note default-y="-10.00" default-x="181.99">
@@ -815,7 +826,7 @@
                 <type>eighth</type>
                 <stem>down</stem>
                 <beam number="1">end</beam>
-                <lyric number="1">
+                <lyric number="1" name="verse1">
                     <syllabic>end</syllabic>
                     <text>ture's</text>
                 </lyric>
@@ -837,7 +848,7 @@
                 <accidental>natural</accidental>
                 <stem>up</stem>
                 <beam number="1">begin</beam>
-                <lyric number="1">
+                <lyric number="1" name="verse1">
                     <syllabic>begin</syllabic>
                     <text>look</text>
                 </lyric>
@@ -852,7 +863,7 @@
                 <type>eighth</type>
                 <stem>up</stem>
                 <beam number="1">end</beam>
-                <lyric number="1">
+                <lyric number="1" name="verse1">
                     <syllabic>end</syllabic>
                     <text>ing</text>
                 </lyric>
@@ -883,7 +894,7 @@
                 <voice>1</voice>
                 <type>half</type>
                 <stem>down</stem>
-                <lyric number="1">
+                <lyric number="1" name="verse1">
                     <syllabic>single</syllabic>
                     <text>dim,</text>
                 </lyric>
@@ -898,7 +909,7 @@
                 <type>eighth</type>
                 <stem>down</stem>
                 <beam number="1">begin</beam>
-                <lyric number="1">
+                <lyric number="1" name="verse1">
                     <syllabic>single</syllabic>
                     <text>but</text>
                 </lyric>
@@ -913,7 +924,7 @@
                 <type>eighth</type>
                 <stem>down</stem>
                 <beam number="1">end</beam>
-                <lyric number="1">
+                <lyric number="1" name="verse1">
                     <syllabic>single</syllabic>
                     <text>these</text>
                 </lyric>
@@ -926,14 +937,14 @@
                     <octave>4</octave>
                 </pitch>
                 <duration>6</duration>
-                <tie type="start"/>
+                <tie type="start" />
                 <voice>1</voice>
                 <type>quarter</type>
                 <stem>up</stem>
                 <notations>
-                    <tied type="start"/>
+                    <tied type="start" />
                 </notations>
-                <lyric number="1">
+                <lyric number="1" name="verse1">
                     <syllabic>single</syllabic>
                     <text>things</text>
                 </lyric>
@@ -944,13 +955,13 @@
                     <octave>4</octave>
                 </pitch>
                 <duration>3</duration>
-                <tie type="stop"/>
+                <tie type="stop" />
                 <voice>1</voice>
                 <type>eighth</type>
                 <stem>up</stem>
                 <beam number="1">begin</beam>
                 <notations>
-                    <tied type="stop"/>
+                    <tied type="stop" />
                 </notations>
             </note>
             <note default-y="-25.00" default-x="221.04">
@@ -963,7 +974,7 @@
                 <type>eighth</type>
                 <stem>up</stem>
                 <beam number="1">end</beam>
-                <lyric number="1">
+                <lyric number="1" name="verse1">
                     <syllabic>single</syllabic>
                     <text>your</text>
                 </lyric>
@@ -986,7 +997,7 @@
                 <accidental>sharp</accidental>
                 <stem>up</stem>
                 <beam number="1">begin</beam>
-                <lyric number="1">
+                <lyric number="1" name="verse1">
                     <syllabic>single</syllabic>
                     <text>hearts</text>
                 </lyric>
@@ -1001,7 +1012,7 @@
                 <type>eighth</type>
                 <stem>up</stem>
                 <beam number="1">end</beam>
-                <lyric number="1">
+                <lyric number="1" name="verse1">
                     <syllabic>single</syllabic>
                     <text>can</text>
                 </lyric>
@@ -1023,7 +1034,7 @@
                 <voice>1</voice>
                 <type>half</type>
                 <stem>down</stem>
-                <lyric number="1">
+                <lyric number="1" name="verse1">
                     <syllabic>single</syllabic>
                     <text>rise</text>
                 </lyric>
@@ -1043,7 +1054,7 @@
                 <voice>1</voice>
                 <type>quarter</type>
                 <stem>down</stem>
-                <lyric number="1">
+                <lyric number="1" name="verse1">
                     <syllabic>begin</syllabic>
                     <text>a</text>
                 </lyric>
@@ -1064,9 +1075,9 @@
                 <duration>18</duration>
                 <voice>1</voice>
                 <type>half</type>
-                <dot/>
+                <dot />
                 <stem>down</stem>
-                <lyric number="1">
+                <lyric number="1" name="verse1">
                     <syllabic>end</syllabic>
                     <text>bove</text>
                 </lyric>
@@ -1083,7 +1094,7 @@
                 </system-layout>
             </print>
             <note>
-                <rest/>
+                <rest />
                 <duration>6</duration>
                 <voice>1</voice>
                 <type>quarter</type>
@@ -1109,9 +1120,9 @@
                 <stem>down</stem>
                 <beam number="1">begin</beam>
                 <notations>
-                    <tuplet type="start" bracket="no"/>
+                    <tuplet type="start" bracket="no" />
                 </notations>
-                <lyric number="1">
+                <lyric number="1" name="verse1">
                     <syllabic>single</syllabic>
                     <text>Once</text>
                 </lyric>
@@ -1131,7 +1142,7 @@
                 </time-modification>
                 <stem>down</stem>
                 <beam number="1">continue</beam>
-                <lyric number="1">
+                <lyric number="1" name="verse1">
                     <syllabic>single</syllabic>
                     <text>in</text>
                 </lyric>
@@ -1151,9 +1162,9 @@
                 <stem>down</stem>
                 <beam number="1">end</beam>
                 <notations>
-                    <tuplet type="stop"/>
+                    <tuplet type="stop" />
                 </notations>
-                <lyric number="1">
+                <lyric number="1" name="verse1">
                     <syllabic>single</syllabic>
                     <text>a</text>
                 </lyric>
@@ -1180,9 +1191,9 @@
                 <stem>down</stem>
                 <beam number="1">begin</beam>
                 <notations>
-                    <tuplet type="start" bracket="no"/>
+                    <tuplet type="start" bracket="no" />
                 </notations>
-                <lyric number="1">
+                <lyric number="1" name="verse1">
                     <syllabic>single</syllabic>
                     <text>while</text>
                 </lyric>
@@ -1201,7 +1212,7 @@
                 </time-modification>
                 <stem>down</stem>
                 <beam number="1">continue</beam>
-                <lyric number="1">
+                <lyric number="1" name="verse1">
                     <syllabic>single</syllabic>
                     <text>he</text>
                 </lyric>
@@ -1222,9 +1233,9 @@
                 <stem>down</stem>
                 <beam number="1">end</beam>
                 <notations>
-                    <tuplet type="stop"/>
+                    <tuplet type="stop" />
                 </notations>
-                <lyric number="1">
+                <lyric number="1" name="verse1">
                     <syllabic>single</syllabic>
                     <text>won't</text>
                 </lyric>
@@ -1246,7 +1257,7 @@
                 <voice>1</voice>
                 <type>half</type>
                 <stem>up</stem>
-                <lyric number="1">
+                <lyric number="1" name="verse1">
                     <syllabic>single</syllabic>
                     <text>call</text>
                 </lyric>
@@ -1261,7 +1272,7 @@
                 <type>eighth</type>
                 <stem>up</stem>
                 <beam number="1">begin</beam>
-                <lyric number="1">
+                <lyric number="1" name="verse1">
                     <syllabic>single</syllabic>
                     <text>but</text>
                 </lyric>
@@ -1276,7 +1287,7 @@
                 <type>eighth</type>
                 <stem>up</stem>
                 <beam number="1">end</beam>
-                <lyric number="1">
+                <lyric number="1" name="verse1">
                     <syllabic>single</syllabic>
                     <text>it's</text>
                 </lyric>
@@ -1299,7 +1310,7 @@
                 <voice>1</voice>
                 <type>half</type>
                 <stem>up</stem>
-                <lyric number="1">
+                <lyric number="1" name="verse1">
                     <syllabic>single</syllabic>
                     <text>all</text>
                 </lyric>
@@ -1320,7 +1331,7 @@
                 <type>eighth</type>
                 <stem>up</stem>
                 <beam number="1">begin</beam>
-                <lyric number="1">
+                <lyric number="1" name="verse1">
                     <syllabic>single</syllabic>
                     <text>in</text>
                 </lyric>
@@ -1335,7 +1346,7 @@
                 <type>eighth</type>
                 <stem>up</stem>
                 <beam number="1">end</beam>
-                <lyric number="1">
+                <lyric number="1" name="verse1">
                     <syllabic>single</syllabic>
                     <text>the</text>
                 </lyric>
@@ -1356,9 +1367,9 @@
                 <duration>18</duration>
                 <voice>1</voice>
                 <type>half</type>
-                <dot/>
+                <dot />
                 <stem>up</stem>
-                <lyric number="1">
+                <lyric number="1" name="verse1">
                     <syllabic>single</syllabic>
                     <text>game</text>
                 </lyric>
@@ -1375,7 +1386,7 @@
                 </system-layout>
             </print>
             <note>
-                <rest/>
+                <rest />
                 <duration>6</duration>
                 <voice>1</voice>
                 <type>quarter</type>
@@ -1395,9 +1406,9 @@
                 <stem>down</stem>
                 <beam number="1">begin</beam>
                 <notations>
-                    <tuplet type="start" bracket="no"/>
+                    <tuplet type="start" bracket="no" />
                 </notations>
-                <lyric number="1">
+                <lyric number="1" name="verse1">
                     <syllabic>single</syllabic>
                     <text>Soon</text>
                 </lyric>
@@ -1417,7 +1428,7 @@
                 </time-modification>
                 <stem>down</stem>
                 <beam number="1">continue</beam>
-                <lyric number="1">
+                <lyric number="1" name="verse1">
                     <syllabic>single</syllabic>
                     <text>he'll</text>
                 </lyric>
@@ -1437,9 +1448,9 @@
                 <stem>down</stem>
                 <beam number="1">end</beam>
                 <notations>
-                    <tuplet type="stop"/>
+                    <tuplet type="stop" />
                 </notations>
-                <lyric number="1">
+                <lyric number="1" name="verse1">
                     <syllabic>single</syllabic>
                     <text>be</text>
                 </lyric>
@@ -1466,9 +1477,9 @@
                 <stem>down</stem>
                 <beam number="1">begin</beam>
                 <notations>
-                    <tuplet type="start" bracket="no"/>
+                    <tuplet type="start" bracket="no" />
                 </notations>
-                <lyric number="1">
+                <lyric number="1" name="verse1">
                     <syllabic>single</syllabic>
                     <text>there</text>
                 </lyric>
@@ -1487,7 +1498,7 @@
                 </time-modification>
                 <stem>down</stem>
                 <beam number="1">continue</beam>
-                <lyric number="1">
+                <lyric number="1" name="verse1">
                     <syllabic>single</syllabic>
                     <text>at</text>
                 </lyric>
@@ -1508,9 +1519,9 @@
                 <stem>down</stem>
                 <beam number="1">end</beam>
                 <notations>
-                    <tuplet type="stop"/>
+                    <tuplet type="stop" />
                 </notations>
-                <lyric number="1">
+                <lyric number="1" name="verse1">
                     <syllabic>single</syllabic>
                     <text>your</text>
                 </lyric>
@@ -1532,7 +1543,7 @@
                 <voice>1</voice>
                 <type>half</type>
                 <stem>up</stem>
-                <lyric number="1">
+                <lyric number="1" name="verse1">
                     <syllabic>single</syllabic>
                     <text>side</text>
                 </lyric>
@@ -1547,7 +1558,7 @@
                 <type>eighth</type>
                 <stem>up</stem>
                 <beam number="1">begin</beam>
-                <lyric number="1">
+                <lyric number="1" name="verse1">
                     <syllabic>single</syllabic>
                     <text>with</text>
                 </lyric>
@@ -1562,7 +1573,7 @@
                 <type>eighth</type>
                 <stem>up</stem>
                 <beam number="1">end</beam>
-                <lyric number="1">
+                <lyric number="1" name="verse1">
                     <syllabic>single</syllabic>
                     <text>a</text>
                 </lyric>
@@ -1585,7 +1596,7 @@
                 <voice>1</voice>
                 <type>half</type>
                 <stem>down</stem>
-                <lyric number="1">
+                <lyric number="1" name="verse1">
                     <syllabic>single</syllabic>
                     <text>sweet</text>
                 </lyric>
@@ -1599,7 +1610,7 @@
                 <voice>1</voice>
                 <type>quarter</type>
                 <stem>up</stem>
-                <lyric number="1">
+                <lyric number="1" name="verse1">
                     <syllabic>begin</syllabic>
                     <text>bou</text>
                 </lyric>
@@ -1618,15 +1629,15 @@
                     <octave>4</octave>
                 </pitch>
                 <duration>18</duration>
-                <tie type="start"/>
+                <tie type="start" />
                 <voice>1</voice>
                 <type>half</type>
-                <dot/>
+                <dot />
                 <stem>up</stem>
                 <notations>
-                    <tied type="start"/>
+                    <tied type="start" />
                 </notations>
-                <lyric number="1">
+                <lyric number="1" name="verse1">
                     <syllabic>end</syllabic>
                     <text>quet,</text>
                 </lyric>
@@ -1639,12 +1650,12 @@
                     <octave>4</octave>
                 </pitch>
                 <duration>12</duration>
-                <tie type="stop"/>
+                <tie type="stop" />
                 <voice>1</voice>
                 <type>half</type>
                 <stem>up</stem>
                 <notations>
-                    <tied type="stop"/>
+                    <tied type="stop" />
                 </notations>
             </note>
             <note default-y="-25.00" default-x="136.44">
@@ -1657,7 +1668,7 @@
                 <type>eighth</type>
                 <stem>up</stem>
                 <beam number="1">begin</beam>
-                <lyric number="1">
+                <lyric number="1" name="verse1">
                     <syllabic>single</syllabic>
                     <text>And</text>
                 </lyric>
@@ -1673,7 +1684,7 @@
                 <type>eighth</type>
                 <stem>up</stem>
                 <beam number="1">end</beam>
-                <lyric number="1">
+                <lyric number="1" name="verse1">
                     <syllabic>single</syllabic>
                     <text>he'll</text>
                 </lyric>
@@ -1698,7 +1709,7 @@
                 <voice>1</voice>
                 <type>half</type>
                 <stem>down</stem>
-                <lyric number="1">
+                <lyric number="1" name="verse1">
                     <syllabic>single</syllabic>
                     <text>kiss</text>
                 </lyric>
@@ -1718,7 +1729,7 @@
                 <voice>1</voice>
                 <type>quarter</type>
                 <stem>up</stem>
-                <lyric number="1">
+                <lyric number="1" name="verse1">
                     <syllabic>single</syllabic>
                     <text>tour</text>
                 </lyric>
@@ -1740,7 +1751,7 @@
                 <voice>1</voice>
                 <type>half</type>
                 <stem>up</stem>
-                <lyric number="1">
+                <lyric number="1" name="verse1">
                     <syllabic>single</syllabic>
                     <text>lips</text>
                 </lyric>
@@ -1755,7 +1766,7 @@
                 <type>eighth</type>
                 <stem>up</stem>
                 <beam number="1">begin</beam>
-                <lyric number="1">
+                <lyric number="1" name="verse1">
                     <syllabic>single</syllabic>
                     <text>and</text>
                 </lyric>
@@ -1770,7 +1781,7 @@
                 <type>eighth</type>
                 <stem>up</stem>
                 <beam number="1">end</beam>
-                <lyric number="1">
+                <lyric number="1" name="verse1">
                     <syllabic>begin</syllabic>
                     <text>ca</text>
                 </lyric>
@@ -1793,7 +1804,7 @@
                 <type>eighth</type>
                 <stem>down</stem>
                 <beam number="1">begin</beam>
-                <lyric number="1">
+                <lyric number="1" name="verse1">
                     <syllabic>end</syllabic>
                     <text>ress</text>
                 </lyric>
@@ -1808,7 +1819,7 @@
                 <type>eighth</type>
                 <stem>down</stem>
                 <beam number="1">end</beam>
-                <lyric number="1">
+                <lyric number="1" name="verse1">
                     <syllabic>single</syllabic>
                     <text>your</text>
                 </lyric>
@@ -1823,7 +1834,7 @@
                 <type>eighth</type>
                 <stem>up</stem>
                 <beam number="1">begin</beam>
-                <lyric number="1">
+                <lyric number="1" name="verse1">
                     <syllabic>begin</syllabic>
                     <text>wai</text>
                 </lyric>
@@ -1838,7 +1849,7 @@
                 <type>eighth</type>
                 <stem>up</stem>
                 <beam number="1">end</beam>
-                <lyric number="1">
+                <lyric number="1" name="verse1">
                     <syllabic>end</syllabic>
                     <text>ting</text>
                 </lyric>
@@ -1853,7 +1864,7 @@
                 <type>eighth</type>
                 <stem>up</stem>
                 <beam number="1">begin</beam>
-                <lyric number="1">
+                <lyric number="1" name="verse1">
                     <syllabic>begin</syllabic>
                     <text>fin</text>
                 </lyric>
@@ -1868,7 +1879,7 @@
                 <type>eighth</type>
                 <stem>up</stem>
                 <beam number="1">end</beam>
-                <lyric number="1">
+                <lyric number="1" name="verse1">
                     <syllabic>end</syllabic>
                     <text>ger</text>
                 </lyric>
@@ -1890,7 +1901,7 @@
                 <voice>1</voice>
                 <type>half</type>
                 <stem>up</stem>
-                <lyric number="1">
+                <lyric number="1" name="verse1">
                     <syllabic>single</syllabic>
                     <text>tips;</text>
                 </lyric>
@@ -1905,7 +1916,7 @@
                 <type>eighth</type>
                 <stem>up</stem>
                 <beam number="1">begin</beam>
-                <lyric number="1">
+                <lyric number="1" name="verse1">
                     <syllabic>single</syllabic>
                     <text>And</text>
                 </lyric>
@@ -1921,7 +1932,7 @@
                 <type>eighth</type>
                 <stem>up</stem>
                 <beam number="1">end</beam>
-                <lyric number="1">
+                <lyric number="1" name="verse1">
                     <syllabic>single</syllabic>
                     <text>your</text>
                 </lyric>
@@ -1943,7 +1954,7 @@
                 <voice>1</voice>
                 <type>half</type>
                 <stem>down</stem>
-                <lyric number="1">
+                <lyric number="1" name="verse1">
                     <syllabic>single</syllabic>
                     <text>hearts</text>
                 </lyric>
@@ -1957,7 +1968,7 @@
                 <voice>1</voice>
                 <type>quarter</type>
                 <stem>down</stem>
-                <lyric number="1">
+                <lyric number="1" name="verse1">
                     <syllabic>single</syllabic>
                     <text>will</text>
                 </lyric>
@@ -1988,7 +1999,7 @@
                 <voice>1</voice>
                 <type>half</type>
                 <stem>down</stem>
-                <lyric number="1">
+                <lyric number="1" name="verse1">
                     <syllabic>single</syllabic>
                     <text>fly</text>
                 </lyric>
@@ -2002,7 +2013,7 @@
                 <voice>1</voice>
                 <type>quarter</type>
                 <stem>down</stem>
-                <lyric number="1">
+                <lyric number="1" name="verse1">
                     <syllabic>begin</syllabic>
                     <text>a</text>
                 </lyric>
@@ -2020,15 +2031,15 @@
                     <octave>4</octave>
                 </pitch>
                 <duration>18</duration>
-                <tie type="start"/>
+                <tie type="start" />
                 <voice>1</voice>
                 <type>half</type>
-                <dot/>
+                <dot />
                 <stem>up</stem>
                 <notations>
-                    <tied type="start"/>
+                    <tied type="start" />
                 </notations>
-                <lyric number="1">
+                <lyric number="1" name="verse1">
                     <syllabic>end</syllabic>
                     <text>way.</text>
                 </lyric>
@@ -2041,22 +2052,22 @@
                     <octave>4</octave>
                 </pitch>
                 <duration>6</duration>
-                <tie type="stop"/>
+                <tie type="stop" />
                 <voice>1</voice>
                 <type>quarter</type>
                 <stem>up</stem>
                 <notations>
-                    <tied type="stop"/>
+                    <tied type="stop" />
                 </notations>
             </note>
             <note>
-                <rest/>
+                <rest />
                 <duration>6</duration>
                 <voice>1</voice>
                 <type>quarter</type>
             </note>
             <note>
-                <rest/>
+                <rest />
                 <duration>6</duration>
                 <voice>1</voice>
                 <type>quarter</type>

--- a/lib/music_xml.dart
+++ b/lib/music_xml.dart
@@ -1,11 +1,14 @@
 export 'src/chord_symbol.dart';
 export 'src/key_signature.dart';
+export 'src/lyric.dart';
 export 'src/measure.dart';
 export 'src/music_xml_document.dart';
 export 'src/music_xml_parser_state.dart';
 export 'src/note.dart';
 export 'src/note_duration.dart';
 export 'src/part.dart';
+export 'src/print.dart';
 export 'src/score_part.dart';
 export 'src/tempo.dart';
 export 'src/time_signature.dart';
+export 'src/tie.dart';

--- a/lib/src/barline.dart
+++ b/lib/src/barline.dart
@@ -1,0 +1,63 @@
+import 'package:music_xml/src/basic_attributes.dart';
+import 'package:music_xml/src/camel_case.dart';
+import 'package:xml/xml.dart';
+
+import 'music_xml_parser_state.dart';
+
+enum BarStyle {
+  dashed,
+  dotted,
+  heavy,
+  heavyHeavy,
+  heavyLight,
+  lightHeavy,
+  lightLight,
+  none,
+  regular,
+  short,
+  tick,
+}
+
+BarStyle _parseBarStyle(String str) => BarStyle.values
+    .firstWhere((e) => e.toString() == 'BarStyle.' + camelCase(str));
+
+/// Internal representation of a MusicXML <barline> element.
+class Barline {
+  BarStyle? barStyle;
+  RightLeftMiddle? location;
+
+  /// Parse the MusicXML <barline> element.
+  factory Barline.parse(XmlElement xmlBarline, MusicXMLParserState state) {
+    BarStyle? barStyle;
+    RightLeftMiddle? location;
+
+    // Parse children
+    for (final child in xmlBarline.childElements) {
+      switch (child.name.local) {
+        case 'bar-style':
+          barStyle = _parseBarStyle(child.text);
+          break;
+        default:
+        // Ignore other tag types because they are not relevant to Magenta.
+      }
+    }
+
+    // Parse attributes
+    for (final attribute in xmlBarline.attributes) {
+      final name = attribute.name.local;
+      final value = attribute.value;
+      switch (name) {
+        case 'location':
+          location = parseRightLeftMiddle(value);
+          break;
+        default:
+          // Add implementation above
+          break;
+      }
+    }
+
+    return Barline(barStyle, location);
+  }
+
+  Barline(this.barStyle, this.location);
+}

--- a/lib/src/basic_attributes.dart
+++ b/lib/src/basic_attributes.dart
@@ -1,0 +1,46 @@
+/// https://www.w3.org/2021/06/musicxml40/musicxml-reference/data-types/start-stop/
+enum StartStop {
+  start,
+  stop,
+}
+
+StartStop parseStartStop(String str) =>
+    StartStop.values.firstWhere((e) => e.toString() == 'StartStop.' + str);
+
+/// https://www.w3.org/2021/06/musicxml40/musicxml-reference/data-types/yes-no/
+bool parseYesNo(String str) => str == 'yes' ? true : false;
+
+/// https://www.w3.org/2021/06/musicxml40/musicxml-reference/data-types/right-left-middle/
+enum RightLeftMiddle {
+  right,
+  left,
+  middle,
+}
+
+RightLeftMiddle parseRightLeftMiddle(String str) => RightLeftMiddle.values
+    .firstWhere((e) => e.toString() == 'RightLeftMiddle.' + str);
+
+/// https://www.w3.org/2021/06/musicxml40/musicxml-reference/elements/root-step/
+enum Step {
+  a,
+  b,
+  c,
+  d,
+  e,
+  f,
+  g,
+}
+
+Step parseStep(String str) =>
+    Step.values.firstWhere((e) => e.toString() == 'Step.' + str.toLowerCase());
+
+/// https://www.w3.org/2021/06/musicxml40/musicxml-reference/data-types/degree-type-value/
+
+enum DegreeType {
+  add,
+  alter,
+  subtract,
+}
+
+DegreeType parseDegreeType(String str) =>
+    DegreeType.values.firstWhere((e) => e.toString() == 'RootStep.' + str);

--- a/lib/src/bass.dart
+++ b/lib/src/bass.dart
@@ -1,0 +1,44 @@
+import 'package:music_xml/src/basic_attributes.dart';
+import 'package:xml/xml.dart';
+
+import 'music_xml_parser_state.dart';
+
+/// Internal representation of a MusicXML <bass> element.
+/// https://www.w3.org/2021/06/musicxml40/musicxml-reference/elements/bass/
+class Bass {
+  final Step step;
+  final double alter;
+  final String? separator;
+
+  /// Parse the MusicXML <bass> element.
+  factory Bass.parse(XmlElement xmlBass, MusicXMLParserState state) {
+    Step? step;
+    double alter = 0.0;
+    String? separator;
+
+    // Parse children
+    for (final child in xmlBass.childElements) {
+      switch (child.name.local) {
+        case 'bass-step':
+          step = parseStep(child.text);
+          break;
+        case 'bass-alter':
+          alter = double.parse(child.text);
+          break;
+        case 'bass-separator':
+          separator = child.text;
+          break;
+        default:
+        // Ignore other tag types because they are not relevant to Magenta.
+      }
+    }
+
+    if (step == null) {
+      throw XmlParserException('Missing "bass-alter" child element.');
+    }
+
+    return Bass(step, alter: alter, separator: separator);
+  }
+
+  Bass(this.step, {this.alter = 0.0, this.separator});
+}

--- a/lib/src/camel_case.dart
+++ b/lib/src/camel_case.dart
@@ -1,0 +1,58 @@
+// Taken from https://pub.dev/documentation/recase)
+// Consider linking that package directly.
+
+/// Convert strings like "British-music" into britishMusic
+String lowerCamelCase(text, {String separator: ''}) {
+  var result = camelCase(text, separator: separator);
+  result = "${result[0].toLowerCase()}${result.substring(1)}";
+  return result;
+}
+
+/// Convert strings like "light-light" into lightLight
+String camelCase(text, {String separator: ''}) {
+  final _words = _groupIntoWords(text);
+
+  List<String> words = _words.map(_upperCaseFirstLetter).toList();
+
+  if (_words.isNotEmpty) {
+    words[0] = words[0].toLowerCase();
+  }
+
+  return words.join(separator);
+}
+
+String _upperCaseFirstLetter(String word) {
+  return '${word.substring(0, 1).toUpperCase()}${word.substring(1).toLowerCase()}';
+}
+
+List<String> _groupIntoWords(String text) {
+  StringBuffer sb = StringBuffer();
+  List<String> words = [];
+  bool isAllCaps = text.toUpperCase() == text;
+
+  for (int i = 0; i < text.length; i++) {
+    String char = text[i];
+    String? nextChar = i + 1 == text.length ? null : text[i + 1];
+
+    if (symbolSet.contains(char)) {
+      continue;
+    }
+
+    sb.write(char);
+
+    bool isEndOfWord = nextChar == null ||
+        (_upperAlphaRegex.hasMatch(nextChar) && !isAllCaps) ||
+        symbolSet.contains(nextChar);
+
+    if (isEndOfWord) {
+      words.add(sb.toString());
+      sb.clear();
+    }
+  }
+
+  return words;
+}
+
+final symbolSet = {' ', '.', '/', '_', '\\', '-'};
+
+final RegExp _upperAlphaRegex = RegExp(r'[A-Z]');

--- a/lib/src/degree.dart
+++ b/lib/src/degree.dart
@@ -1,0 +1,52 @@
+import 'package:music_xml/src/basic_attributes.dart';
+import 'package:xml/xml.dart';
+
+import 'music_xml_parser_state.dart';
+
+/// Internal representation of a MusicXML <degree> element.
+/// https://www.w3.org/2021/06/musicxml40/musicxml-reference/elements/degree/
+class Degree {
+  final int value;
+  final double alter;
+  final DegreeType type;
+
+  /// Parse the MusicXML <degree> element.
+  factory Degree.parse(XmlElement xmlDegree, MusicXMLParserState state) {
+    int? value;
+    double? alter;
+    dynamic type;
+
+    // Parse children
+    for (final child in xmlDegree.childElements) {
+      switch (child.name.local) {
+        case 'degree-value':
+          value = int.parse(child.text);
+          break;
+        case 'degree-alter':
+          alter = double.parse(child.text);
+          break;
+        case 'degree-type':
+          type = parseDegreeType(child.text);
+          break;
+        default:
+        // Ignore other tag types because they are not relevant to Magenta.
+      }
+    }
+
+    if (alter == null) {
+      throw XmlParserException('Missing "degree-alter" child element.');
+    }
+
+    if (value == null) {
+      throw XmlParserException('Missing "degree-value" child element.');
+    }
+
+    if (type == null) {
+      throw XmlParserException('Missing "degree-type" child element.');
+    }
+
+    return Degree(value, alter, type);
+  }
+
+  Degree(this.value, this.alter, this.type);
+}

--- a/lib/src/kind.dart
+++ b/lib/src/kind.dart
@@ -1,0 +1,41 @@
+// https://www.w3.org/2021/06/musicxml40/musicxml-reference/data-types/kind-value/
+import 'package:music_xml/src/camel_case.dart';
+
+enum Kind {
+  augmented,
+  augmentedSeventh,
+  diminished,
+  diminishedSeventh,
+  dominant,
+  dominant11th,
+  dominant13th,
+  dominantNinth,
+  trench,
+  german,
+  halfDiminished,
+  italian,
+  major,
+  major11th,
+  major13th,
+  majorMinor,
+  majorNinth,
+  majorSeventh,
+  majorSixth,
+  minor,
+  minor11th,
+  minor13th,
+  minorNinth,
+  minorSeventh,
+  minorSixth,
+  neapolitan,
+  none,
+  other,
+  pedal,
+  power,
+  suspendedFourth,
+  suspendedSecond,
+  tristan,
+}
+
+Kind parseKind(String str) => Kind.values
+    .firstWhere((e) => e.toString() == 'Kind.' + lowerCamelCase(str));

--- a/lib/src/lyric.dart
+++ b/lib/src/lyric.dart
@@ -1,0 +1,85 @@
+import 'package:xml/xml.dart';
+
+import 'music_xml_parser_state.dart';
+
+/// The value of the <syllabic> child element.
+enum Syllabic {
+  single,
+  begin,
+  end,
+  middle,
+}
+
+class LyricItem {
+  Syllabic? syllabic;
+  String text;
+  String? elision;
+
+  LyricItem(this.syllabic, this.text, this.elision);
+}
+
+/// Internal representation of a MusicXML <lyric> element.
+class Lyric {
+  final List<LyricItem> items;
+  String? name;
+
+  /// Returns the elision of the first item
+  Syllabic? get syllabic => items.first.syllabic;
+
+  /// Returns the syllabic of the first item
+  String get text => items.first.text;
+
+  /// Parse the MusicXML <lyric> element.
+  factory Lyric.parse(XmlElement xmlLyric, MusicXMLParserState state) {
+    final items = <LyricItem>[];
+
+    Syllabic? syllabic;
+    String? text;
+    String? name;
+    String? elision;
+
+    for (final child in xmlLyric.childElements) {
+      switch (child.name.local) {
+        case 'syllabic':
+          syllabic = Syllabic.values
+              .firstWhere((e) => e.toString() == 'Syllabic.' + child.text);
+          break;
+        case 'text':
+          text = child.text;
+          break;
+        case 'elision':
+          items.add(LyricItem(syllabic, text!, elision));
+          elision = child.text;
+          syllabic = null;
+          text = null;
+          break;
+        default:
+        // Ignore other tag types because they are not relevant to Magenta.
+      }
+    }
+
+    if (text == null) {
+      throw XmlParserException('Missing child: text');
+    }
+    items.add(LyricItem(syllabic, text, elision));
+
+    name = _parseName(xmlLyric.attributes);
+
+    return Lyric(items, name);
+  }
+
+  Lyric(this.items, this.name);
+
+  /// Parses the name attribute
+  static String? _parseName(Iterable<XmlAttribute> attributes) {
+    String? result;
+    for (final attribute in attributes) {
+      if (attribute.name.local == 'name') {
+        result = attribute.value;
+        break;
+      }
+    }
+
+    return result;
+  }
+}

--- a/lib/src/measure.dart
+++ b/lib/src/measure.dart
@@ -1,3 +1,5 @@
+import 'package:music_xml/src/barline.dart';
+import 'package:music_xml/src/print.dart';
 import 'package:xml/xml.dart';
 
 import 'chord_symbol.dart';
@@ -13,9 +15,11 @@ class Measure {
   final notes = <Note>[];
   final chordSymbols = <ChordSymbol>[];
   final tempos = <Tempo>[];
+  final prints = <Print>[];
   TimeSignature? timeSignature;
   KeySignature? keySignature;
   int duration = 0;
+  Barline? barline;
 
   Measure();
 
@@ -61,6 +65,12 @@ class Measure {
         case 'harmony':
           final chordSymbol = ChordSymbol.parse(child, state);
           chordSymbols.add(chordSymbol);
+          break;
+        case 'print':
+          prints.add(Print.parse(child, state));
+          break;
+        case 'barline':
+          barline = Barline.parse(child, state);
           break;
         default:
         // Ignore other tag types because they are not relevant to Magenta.

--- a/lib/src/note.dart
+++ b/lib/src/note.dart
@@ -1,3 +1,5 @@
+import 'package:music_xml/src/lyric.dart';
+import 'package:music_xml/src/tie.dart';
 import 'package:xml/xml.dart';
 
 import 'music_xml_parser_state.dart';
@@ -14,6 +16,8 @@ class Note {
   final bool isGraceNote;
   final NoteDuration noteDuration;
   MapEntry<String, int>? pitch;
+  Iterable<Lyric>? lyrics;
+  Tie? tie;
 
   /// Parse the MusicXML <note> element.
   factory Note.parse(XmlElement xmlNote, MusicXMLParserState state) {
@@ -25,6 +29,9 @@ class Note {
     var dots = 0;
     String? type;
     double? tupletRatio;
+
+    final List<Lyric> lyrics = [];
+    Tie? tie;
 
     MapEntry<String, int>? pitch;
     for (final child in xmlNote.childElements) {
@@ -54,6 +61,12 @@ class Note {
           // A time-modification element represents a tuplet_ratio
           tupletRatio = _parseTuplet(child);
           break;
+        case 'lyric':
+          lyrics.add(Lyric.parse(child, state));
+          break;
+        case 'tie':
+          tie = Tie.parse(child, state);
+          break;
         case 'unpitched':
           throw UnsupportedError('Unpitched notes are not supported');
         default:
@@ -80,6 +93,8 @@ class Note {
       isGraceNote,
       noteDuration,
       pitch,
+      lyrics.isNotEmpty ? lyrics : null,
+      tie,
     );
   }
 
@@ -93,6 +108,8 @@ class Note {
     this.isGraceNote,
     this.noteDuration,
     this.pitch,
+    this.lyrics,
+    this.tie,
   );
 
   /// Parse the MusicXML <pitch> element.

--- a/lib/src/print.dart
+++ b/lib/src/print.dart
@@ -1,0 +1,62 @@
+import 'package:music_xml/src/basic_attributes.dart';
+import 'package:xml/xml.dart';
+
+import 'music_xml_parser_state.dart';
+
+/// Internal representation of a MusicXML <print> element.
+class Print {
+  final int? blankPage;
+  bool newPage;
+  bool newSystem;
+  int? pageNumber;
+  double? staffSpacing;
+
+  /// Parse the MusicXML <print> element.
+  factory Print.parse(XmlElement xmlPrint, MusicXMLParserState state) {
+    int? blankPage;
+    bool? newPage;
+    bool? newSystem;
+    int? pageNumber;
+    double? staffSpacing;
+
+    for (final attribute in xmlPrint.attributes) {
+      final name = attribute.name.local;
+      final value = attribute.value;
+      switch (name) {
+        case 'blank-page':
+          blankPage = int.parse(value);
+          break;
+        case 'new-page':
+          newPage = parseYesNo(value);
+          break;
+        case 'new-system':
+          newSystem = parseYesNo(value);
+          break;
+        case 'page-number':
+          pageNumber = int.parse(value);
+          break;
+        case 'staff-spacing':
+          staffSpacing = double.parse(value);
+          break;
+        default:
+        // Add implementation above
+      }
+    }
+
+    return Print(
+      blankPage,
+      newPage ?? false,
+      newSystem ?? false,
+      pageNumber,
+      staffSpacing,
+    );
+  }
+
+  Print(
+    this.blankPage,
+    this.newPage,
+    this.newSystem,
+    this.pageNumber,
+    this.staffSpacing,
+  );
+}

--- a/lib/src/root.dart
+++ b/lib/src/root.dart
@@ -1,0 +1,39 @@
+import 'package:music_xml/src/basic_attributes.dart';
+import 'package:xml/xml.dart';
+
+import 'music_xml_parser_state.dart';
+
+/// Internal representation of a MusicXML <root> element.
+/// https://www.w3.org/2021/06/musicxml40/musicxml-reference/elements/root/
+class Root {
+  final Step step;
+  final double alter;
+
+  /// Parse the MusicXML <root> element.
+  factory Root.parse(XmlElement xmlRoot, MusicXMLParserState state) {
+    Step? rootStep;
+    double rootAlter = 0.0;
+
+    // Parse children
+    for (final child in xmlRoot.childElements) {
+      switch (child.name.local) {
+        case 'root-step':
+          rootStep = parseStep(child.text);
+          break;
+        case 'root-alter':
+          rootAlter = double.parse(child.text);
+          break;
+        default:
+        // Ignore other tag types because they are not relevant to Magenta.
+      }
+    }
+
+    if (rootStep == null) {
+      throw XmlParserException('Missing "root-alter" child element.');
+    }
+
+    return Root(rootStep, alter: rootAlter);
+  }
+
+  Root(this.step, {this.alter = 0.0});
+}

--- a/lib/src/tie.dart
+++ b/lib/src/tie.dart
@@ -1,0 +1,29 @@
+import 'package:music_xml/src/basic_attributes.dart';
+import 'package:xml/xml.dart';
+
+import 'music_xml_parser_state.dart';
+
+/// Internal representation of a MusicXML <tie> element.
+class Tie {
+  final StartStop type;
+
+  /// Parse the MusicXML <tie> element.
+  factory Tie.parse(XmlElement xmlTie, MusicXMLParserState state) {
+    StartStop? startStop = _parseType(xmlTie);
+    return Tie(startStop);
+  }
+
+  Tie(this.type);
+
+  /// Parses a type attribute
+  static StartStop _parseType(XmlElement xmlTie) {
+    try {
+      final value =
+          xmlTie.attributes.firstWhere((e) => e.name.local == 'type').value;
+      return parseStartStop(value);
+    } catch (e) {
+      throw throw XmlParserException(
+          'Invalid <tie>. "type" attribute missing or invalid.');
+    }
+  }
+}

--- a/test/assets/musicXML.xml
+++ b/test/assets/musicXML.xml
@@ -1,2069 +1,2080 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 2.0 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">
 <score-partwise version="2.0">
-    <work>
-        <work-number></work-number>
-        <work-title></work-title>
-    </work>
-    <movement-number></movement-number>
-    <movement-title>It's All In The Game</movement-title>
-    <identification>
-        <creator type="composer">&amp; Nobel Prize Winner), Charles Gate Dawes (V.P. of U.S.A.</creator>
-        <creator type="poet">Carl Sigman</creator>
-        <rights>All Rights Reserved</rights>
-        <encoding>
-            <software>MuseScore 1.2</software>
-            <encoding-date>2012-04-30</encoding-date>
-            <software>ProxyMusic 2.0 c</software>
-        </encoding>
-        <source>http://wikifonia.org/node/15933/revisions/21292/view</source>
-    </identification>
-    <defaults>
-        <scaling>
-            <millimeters>5.7</millimeters>
-            <tenths>40</tenths>
-        </scaling>
-        <page-layout>
-            <page-height>2084.21</page-height>
-            <page-width>1473.68</page-width>
-            <page-margins type="both">
-                <left-margin>70.1754</left-margin>
-                <right-margin>70.1754</right-margin>
-                <top-margin>70.1754</top-margin>
-                <bottom-margin>140.351</bottom-margin>
-            </page-margins>
-        </page-layout>
-    </defaults>
-    <credit page="1">
-        <credit-words font-size="24" default-y="2014.04" default-x="736.842" justify="center" valign="top">It's All In The Game</credit-words>
-    </credit>
-    <credit page="1">
-        <credit-words font-size="12" default-y="1951.17" default-x="1403.51" justify="right" valign="top">Charles Gate Dawes</credit-words>
-    </credit>
-    <credit page="1">
-        <credit-words font-size="12" default-y="1951.17" default-x="70.1754" justify="left" valign="top">Carl Sigman</credit-words>
-    </credit>
-    <part-list>
-        <score-part id="P1">
-            <part-name></part-name>
-            <score-instrument id="P1-I3">
-                <instrument-name></instrument-name>
-            </score-instrument>
-            <midi-instrument id="P1-I3">
-                <midi-channel>1</midi-channel>
-                <midi-program>41</midi-program>
-                <volume>78.7402</volume>
-                <pan>0</pan>
-            </midi-instrument>
-        </score-part>
-    </part-list>
-    <part id="P1">
-        <measure width="492.75" number="1">
-            <print>
-                <system-layout>
-                    <system-margins>
-                        <left-margin>3.00</left-margin>
-                        <right-margin>0.00</right-margin>
-                    </system-margins>
-                    <top-system-distance>302.20</top-system-distance>
-                </system-layout>
-            </print>
-            <attributes>
-                <divisions>6</divisions>
-                <key>
-                    <fifths>-1</fifths>
-                    <mode>major</mode>
-                </key>
-                <time>
-                    <beats>3</beats>
-                    <beat-type>4</beat-type>
-                </time>
-                <clef>
-                    <sign>G</sign>
-                    <line>2</line>
-                </clef>
-            </attributes>
-            <note>
-                <rest/>
-                <duration>6</duration>
-                <voice>1</voice>
-                <type>quarter</type>
-            </note>
-            <note default-y="-25.00" default-x="186.28">
-                <pitch>
-                    <step>A</step>
-                    <octave>4</octave>
-                </pitch>
-                <duration>2</duration>
-                <voice>1</voice>
-                <type>eighth</type>
-                <time-modification>
-                    <actual-notes>3</actual-notes>
-                    <normal-notes>2</normal-notes>
-                </time-modification>
-                <stem>down</stem>
-                <beam number="1">begin</beam>
-                <notations>
-                    <tuplet type="start" bracket="no"/>
-                </notations>
-                <lyric number="1">
-                    <syllabic>begin</syllabic>
-                    <text>Ma</text>
-                </lyric>
-            </note>
-            <note default-y="-20.00" default-x="237.10">
-                <pitch>
-                    <step>B</step>
-                    <alter>-1</alter>
-                    <octave>4</octave>
-                </pitch>
-                <duration>2</duration>
-                <voice>1</voice>
-                <type>eighth</type>
-                <time-modification>
-                    <actual-notes>3</actual-notes>
-                    <normal-notes>2</normal-notes>
-                </time-modification>
-                <stem>down</stem>
-                <beam number="1">continue</beam>
-                <lyric number="1">
-                    <syllabic>end</syllabic>
-                    <text>ny</text>
-                </lyric>
-            </note>
-            <note default-y="-15.00" default-x="287.91">
-                <pitch>
-                    <step>C</step>
-                    <octave>5</octave>
-                </pitch>
-                <duration>2</duration>
-                <voice>1</voice>
-                <type>eighth</type>
-                <time-modification>
-                    <actual-notes>3</actual-notes>
-                    <normal-notes>2</normal-notes>
-                </time-modification>
-                <stem>down</stem>
-                <beam number="1">end</beam>
-                <notations>
-                    <tuplet type="stop"/>
-                </notations>
-                <lyric number="1">
-                    <syllabic>single</syllabic>
-                    <text>a</text>
-                </lyric>
-            </note>
-            <note default-y="-10.00" default-x="338.72">
-                <pitch>
-                    <step>D</step>
-                    <octave>5</octave>
-                </pitch>
-                <duration>2</duration>
-                <voice>1</voice>
-                <type>eighth</type>
-                <time-modification>
-                    <actual-notes>3</actual-notes>
-                    <normal-notes>2</normal-notes>
-                </time-modification>
-                <stem>down</stem>
-                <beam number="1">begin</beam>
-                <notations>
-                    <tuplet type="start" bracket="no"/>
-                </notations>
-                <lyric number="1">
-                    <syllabic>single</syllabic>
-                    <text>tear</text>
-                </lyric>
-            </note>
-            <note default-y="-15.00" default-x="389.53">
-                <pitch>
-                    <step>C</step>
-                    <octave>5</octave>
-                </pitch>
-                <duration>2</duration>
-                <voice>1</voice>
-                <type>eighth</type>
-                <time-modification>
-                    <actual-notes>3</actual-notes>
-                    <normal-notes>2</normal-notes>
-                </time-modification>
-                <stem>down</stem>
-                <beam number="1">continue</beam>
-                <lyric number="1">
-                    <syllabic>single</syllabic>
-                    <text>has</text>
-                </lyric>
-            </note>
-            <note default-y="-20.00" default-x="440.34">
-                <pitch>
-                    <step>B</step>
-                    <alter>-1</alter>
-                    <octave>4</octave>
-                </pitch>
-                <duration>2</duration>
-                <voice>1</voice>
-                <type>eighth</type>
-                <time-modification>
-                    <actual-notes>3</actual-notes>
-                    <normal-notes>2</normal-notes>
-                </time-modification>
-                <stem>down</stem>
-                <beam number="1">end</beam>
-                <notations>
-                    <tuplet type="stop"/>
-                </notations>
-                <lyric number="1">
-                    <syllabic>single</syllabic>
-                    <text>to</text>
-                </lyric>
-            </note>
-        </measure>
-        <measure width="299.79" number="2">
-            <harmony print-frame="no">
-                <root>
-                    <root-step>F</root-step>
-                </root>
-                <kind text="">major</kind>
-            </harmony>
-            <note default-y="-25.00" default-x="19.73">
-                <pitch>
-                    <step>A</step>
-                    <octave>4</octave>
-                </pitch>
-                <duration>12</duration>
-                <voice>1</voice>
-                <type>half</type>
-                <stem>up</stem>
-                <lyric number="1">
-                    <syllabic>single</syllabic>
-                    <text>fall</text>
-                </lyric>
-            </note>
-            <note default-y="-30.00" default-x="165.59">
-                <pitch>
-                    <step>G</step>
-                    <octave>4</octave>
-                </pitch>
-                <duration>3</duration>
-                <voice>1</voice>
-                <type>eighth</type>
-                <stem>up</stem>
-                <beam number="1">begin</beam>
-                <lyric number="1">
-                    <syllabic>single</syllabic>
-                    <text>but</text>
-                </lyric>
-            </note>
-            <note default-y="-40.00" default-x="231.89">
-                <pitch>
-                    <step>E</step>
-                    <octave>4</octave>
-                </pitch>
-                <duration>3</duration>
-                <voice>1</voice>
-                <type>eighth</type>
-                <stem>up</stem>
-                <beam number="1">end</beam>
-                <lyric number="1">
-                    <syllabic>single</syllabic>
-                    <text>it's</text>
-                </lyric>
-            </note>
-        </measure>
-        <measure width="288.05" number="3">
-            <harmony print-frame="no">
-                <root>
-                    <root-step>B</root-step>
-                    <root-alter>-1</root-alter>
-                </root>
-                <kind text="">major</kind>
-            </harmony>
-            <note default-y="-45.00" default-x="16.01">
-                <pitch>
-                    <step>D</step>
-                    <octave>4</octave>
-                </pitch>
-                <duration>12</duration>
-                <voice>1</voice>
-                <type>half</type>
-                <stem>up</stem>
-                <lyric number="1">
-                    <syllabic>single</syllabic>
-                    <text>all</text>
-                </lyric>
-            </note>
-            <harmony print-frame="no">
-                <root>
-                    <root-step>C</root-step>
-                </root>
-                <kind text="7">dominant</kind>
-            </harmony>
-            <note default-y="-30.00" default-x="157.67">
-                <pitch>
-                    <step>G</step>
-                    <octave>4</octave>
-                </pitch>
-                <duration>3</duration>
-                <voice>1</voice>
-                <type>eighth</type>
-                <stem>up</stem>
-                <beam number="1">begin</beam>
-                <lyric number="1">
-                    <syllabic>single</syllabic>
-                    <text>in</text>
-                </lyric>
-            </note>
-            <note default-y="-40.00" default-x="222.06">
-                <pitch>
-                    <step>E</step>
-                    <octave>4</octave>
-                </pitch>
-                <duration>3</duration>
-                <voice>1</voice>
-                <type>eighth</type>
-                <stem>up</stem>
-                <beam number="1">end</beam>
-                <lyric number="1">
-                    <syllabic>single</syllabic>
-                    <text>the</text>
-                </lyric>
-            </note>
-        </measure>
-        <measure width="249.75" number="4">
-            <harmony print-frame="no">
-                <root>
-                    <root-step>F</root-step>
-                </root>
-                <kind text="">major</kind>
-            </harmony>
-            <note default-y="-50.00" default-x="29.04">
-                <pitch>
-                    <step>C</step>
-                    <octave>4</octave>
-                </pitch>
-                <duration>18</duration>
-                <voice>1</voice>
-                <type>half</type>
-                <dot/>
-                <stem>up</stem>
-                <lyric number="1">
-                    <syllabic>single</syllabic>
-                    <text>game</text>
-                </lyric>
-            </note>
-        </measure>
-        <measure width="444.40" number="5">
-            <print new-system="yes">
-                <system-layout>
-                    <system-margins>
-                        <left-margin>3.00</left-margin>
-                        <right-margin>0.00</right-margin>
-                    </system-margins>
-                    <system-distance>166.96</system-distance>
-                </system-layout>
-            </print>
-            <note>
-                <rest/>
-                <duration>6</duration>
-                <voice>1</voice>
-                <type>quarter</type>
-            </note>
-            <note default-y="-25.00" default-x="117.71">
-                <pitch>
-                    <step>A</step>
-                    <octave>4</octave>
-                </pitch>
-                <duration>2</duration>
-                <voice>1</voice>
-                <type>eighth</type>
-                <time-modification>
-                    <actual-notes>3</actual-notes>
-                    <normal-notes>2</normal-notes>
-                </time-modification>
-                <stem>down</stem>
-                <beam number="1">begin</beam>
-                <notations>
-                    <tuplet type="start" bracket="no"/>
-                </notations>
-                <lyric number="1">
-                    <syllabic>single</syllabic>
-                    <text>All</text>
-                </lyric>
-            </note>
-            <note default-y="-20.00" default-x="171.89">
-                <pitch>
-                    <step>B</step>
-                    <alter>-1</alter>
-                    <octave>4</octave>
-                </pitch>
-                <duration>2</duration>
-                <voice>1</voice>
-                <type>eighth</type>
-                <time-modification>
-                    <actual-notes>3</actual-notes>
-                    <normal-notes>2</normal-notes>
-                </time-modification>
-                <stem>down</stem>
-                <beam number="1">continue</beam>
-                <lyric number="1">
-                    <syllabic>single</syllabic>
-                    <text>in</text>
-                </lyric>
-            </note>
-            <note default-y="-15.00" default-x="226.07">
-                <pitch>
-                    <step>C</step>
-                    <octave>5</octave>
-                </pitch>
-                <duration>2</duration>
-                <voice>1</voice>
-                <type>eighth</type>
-                <time-modification>
-                    <actual-notes>3</actual-notes>
-                    <normal-notes>2</normal-notes>
-                </time-modification>
-                <stem>down</stem>
-                <beam number="1">end</beam>
-                <notations>
-                    <tuplet type="stop"/>
-                </notations>
-                <lyric number="1">
-                    <syllabic>single</syllabic>
-                    <text>the</text>
-                </lyric>
-            </note>
-            <harmony print-frame="no">
-                <root>
-                    <root-step>B</root-step>
-                    <root-alter>-1</root-alter>
-                </root>
-                <kind text="Maj7">major-seventh</kind>
-            </harmony>
-            <note default-y="-10.00" default-x="280.25">
-                <pitch>
-                    <step>D</step>
-                    <octave>5</octave>
-                </pitch>
-                <duration>2</duration>
-                <voice>1</voice>
-                <type>eighth</type>
-                <time-modification>
-                    <actual-notes>3</actual-notes>
-                    <normal-notes>2</normal-notes>
-                </time-modification>
-                <stem>down</stem>
-                <beam number="1">begin</beam>
-                <notations>
-                    <tuplet type="start" bracket="no"/>
-                </notations>
-                <lyric number="1">
-                    <syllabic>begin</syllabic>
-                    <text>won</text>
-                </lyric>
-            </note>
-            <note default-y="-15.00" default-x="334.43">
-                <pitch>
-                    <step>C</step>
-                    <octave>5</octave>
-                </pitch>
-                <duration>2</duration>
-                <voice>1</voice>
-                <type>eighth</type>
-                <time-modification>
-                    <actual-notes>3</actual-notes>
-                    <normal-notes>2</normal-notes>
-                </time-modification>
-                <stem>down</stem>
-                <beam number="1">continue</beam>
-                <lyric number="1">
-                    <syllabic>middle</syllabic>
-                    <text>der</text>
-                </lyric>
-            </note>
-            <note default-y="-20.00" default-x="388.62">
-                <pitch>
-                    <step>B</step>
-                    <alter>-1</alter>
-                    <octave>4</octave>
-                </pitch>
-                <duration>2</duration>
-                <voice>1</voice>
-                <type>eighth</type>
-                <time-modification>
-                    <actual-notes>3</actual-notes>
-                    <normal-notes>2</normal-notes>
-                </time-modification>
-                <stem>down</stem>
-                <beam number="1">end</beam>
-                <notations>
-                    <tuplet type="stop"/>
-                </notations>
-                <lyric number="1">
-                    <syllabic>end</syllabic>
-                    <text>ful</text>
-                </lyric>
-            </note>
-        </measure>
-        <measure width="336.45" number="6">
-            <harmony print-frame="no">
-                <root>
-                    <root-step>F</root-step>
-                </root>
-                <kind text="">major</kind>
-            </harmony>
-            <note default-y="-25.00" default-x="29.04">
-                <pitch>
-                    <step>A</step>
-                    <octave>4</octave>
-                </pitch>
-                <duration>12</duration>
-                <voice>1</voice>
-                <type>half</type>
-                <stem>up</stem>
-                <lyric number="1">
-                    <syllabic>single</syllabic>
-                    <text>game</text>
-                </lyric>
-            </note>
-            <note default-y="-15.00" default-x="189.23">
-                <pitch>
-                    <step>C</step>
-                    <octave>5</octave>
-                </pitch>
-                <duration>3</duration>
-                <voice>1</voice>
-                <type>eighth</type>
-                <stem>up</stem>
-                <beam number="1">begin</beam>
-                <lyric number="1">
-                    <syllabic>single</syllabic>
-                    <text>that</text>
-                </lyric>
-            </note>
-            <note default-y="-25.00" default-x="262.04">
-                <pitch>
-                    <step>A</step>
-                    <octave>4</octave>
-                </pitch>
-                <duration>3</duration>
-                <voice>1</voice>
-                <type>eighth</type>
-                <stem>up</stem>
-                <beam number="1">end</beam>
-                <lyric number="1">
-                    <syllabic>single</syllabic>
-                    <text>we</text>
-                </lyric>
-            </note>
-        </measure>
-        <measure width="291.90" number="7">
-            <harmony print-frame="no">
-                <root>
-                    <root-step>B</root-step>
-                    <root-alter>-1</root-alter>
-                </root>
-                <kind text="">major</kind>
-            </harmony>
-            <note default-y="-10.00" default-x="29.67">
-                <pitch>
-                    <step>D</step>
-                    <octave>5</octave>
-                </pitch>
-                <duration>12</duration>
-                <voice>1</voice>
-                <type>half</type>
-                <stem>down</stem>
-                <lyric number="1">
-                    <syllabic>single</syllabic>
-                    <text>know</text>
-                </lyric>
-            </note>
-            <note default-y="-35.00" default-x="190.06">
-                <pitch>
-                    <step>F</step>
-                    <octave>4</octave>
-                </pitch>
-                <duration>6</duration>
-                <voice>1</voice>
-                <type>quarter</type>
-                <stem>up</stem>
-                <lyric number="1">
-                    <syllabic>single</syllabic>
-                    <text>as</text>
-                </lyric>
-            </note>
-        </measure>
-        <measure width="257.59" number="8">
-            <harmony print-frame="no">
-                <root>
-                    <root-step>F</root-step>
-                </root>
-                <kind text="">major</kind>
-            </harmony>
-            <note default-y="-25.00" default-x="26.88">
-                <pitch>
-                    <step>A</step>
-                    <octave>4</octave>
-                </pitch>
-                <duration>18</duration>
-                <tie type="start"/>
-                <voice>1</voice>
-                <type>half</type>
-                <dot/>
-                <stem>up</stem>
-                <notations>
-                    <tied type="start"/>
-                </notations>
-                <lyric number="1">
-                    <syllabic>single</syllabic>
-                    <text>love.</text>
-                </lyric>
-            </note>
-        </measure>
-        <measure width="329.02" number="9">
-            <print new-system="yes">
-                <system-layout>
-                    <system-margins>
-                        <left-margin>3.00</left-margin>
-                        <right-margin>0.00</right-margin>
-                    </system-margins>
-                    <system-distance>166.96</system-distance>
-                </system-layout>
-            </print>
-            <note default-y="-25.00" default-x="12.00">
-                <pitch>
-                    <step>A</step>
-                    <octave>4</octave>
-                </pitch>
-                <duration>6</duration>
-                <tie type="stop"/>
-                <voice>1</voice>
-                <type>quarter</type>
-                <stem>up</stem>
-                <notations>
-                    <tied type="stop"/>
-                </notations>
-            </note>
-            <note>
-                <rest/>
-                <duration>6</duration>
-                <voice>1</voice>
-                <type>quarter</type>
-            </note>
-            <note default-y="-25.00" default-x="206.10">
-                <pitch>
-                    <step>A</step>
-                    <octave>4</octave>
-                </pitch>
-                <duration>3</duration>
-                <voice>1</voice>
-                <type>eighth</type>
-                <stem>up</stem>
-                <beam number="1">begin</beam>
-                <lyric number="1">
-                    <syllabic>single</syllabic>
-                    <text>You</text>
-                </lyric>
-            </note>
-            <note default-y="-20.00" default-x="266.76">
-                <pitch>
-                    <step>B</step>
-                    <alter>-1</alter>
-                    <octave>4</octave>
-                </pitch>
-                <duration>3</duration>
-                <voice>1</voice>
-                <type>eighth</type>
-                <stem>up</stem>
-                <beam number="1">end</beam>
-                <lyric number="1">
-                    <syllabic>single</syllabic>
-                    <text>have</text>
-                </lyric>
-            </note>
-        </measure>
-        <measure width="301.46" number="10">
-            <note default-y="-15.00" default-x="32.16">
-                <pitch>
-                    <step>C</step>
-                    <octave>5</octave>
-                </pitch>
-                <duration>12</duration>
-                <voice>1</voice>
-                <type>half</type>
-                <stem>down</stem>
-                <lyric number="1">
-                    <syllabic>single</syllabic>
-                    <text>words</text>
-                </lyric>
-            </note>
-            <note default-y="-50.00" default-x="196.90">
-                <pitch>
-                    <step>C</step>
-                    <octave>4</octave>
-                </pitch>
-                <duration>6</duration>
-                <voice>1</voice>
-                <type>quarter</type>
-                <stem>up</stem>
-                <lyric number="1">
-                    <syllabic>single</syllabic>
-                    <text>with</text>
-                </lyric>
-            </note>
-        </measure>
-        <measure width="322.61" number="11">
-            <harmony print-frame="no">
-                <root>
-                    <root-step>D</root-step>
-                </root>
-                <kind text="m">minor</kind>
-            </harmony>
-            <note default-y="-45.00" default-x="22.23">
-                <pitch>
-                    <step>D</step>
-                    <octave>4</octave>
-                </pitch>
-                <duration>12</duration>
-                <voice>1</voice>
-                <type>half</type>
-                <stem>up</stem>
-                <lyric number="1">
-                    <syllabic>single</syllabic>
-                    <text>him</text>
-                </lyric>
-            </note>
-            <note default-y="-25.00" default-x="178.73">
-                <pitch>
-                    <step>A</step>
-                    <octave>4</octave>
-                </pitch>
-                <duration>3</duration>
-                <voice>1</voice>
-                <type>eighth</type>
-                <stem>up</stem>
-                <beam number="1">begin</beam>
-                <lyric number="1">
-                    <syllabic>single</syllabic>
-                    <text>and</text>
-                </lyric>
-            </note>
-            <note default-y="-20.00" default-x="249.87">
-                <pitch>
-                    <step>B</step>
-                    <alter>-1</alter>
-                    <octave>4</octave>
-                </pitch>
-                <duration>3</duration>
-                <voice>1</voice>
-                <type>eighth</type>
-                <stem>up</stem>
-                <beam number="1">end</beam>
-                <lyric number="1">
-                    <syllabic>single</syllabic>
-                    <text>your</text>
-                </lyric>
-            </note>
-        </measure>
-        <measure width="377.24" number="12">
-            <harmony print-frame="no">
-                <root>
-                    <root-step>F</root-step>
-                </root>
-                <kind text="">major</kind>
-            </harmony>
-            <note default-y="-15.00" default-x="14.15">
-                <pitch>
-                    <step>C</step>
-                    <octave>5</octave>
-                </pitch>
-                <duration>6</duration>
-                <tie type="start"/>
-                <voice>1</voice>
-                <type>quarter</type>
-                <stem>down</stem>
-                <notations>
-                    <tied type="start"/>
-                </notations>
-                <lyric number="1">
-                    <syllabic>begin</syllabic>
-                    <text>fu</text>
-                </lyric>
-            </note>
-            <note default-y="-15.00" default-x="117.43">
-                <pitch>
-                    <step>C</step>
-                    <octave>5</octave>
-                </pitch>
-                <duration>3</duration>
-                <tie type="stop"/>
-                <voice>1</voice>
-                <type>eighth</type>
-                <stem>down</stem>
-                <beam number="1">begin</beam>
-                <notations>
-                    <tied type="stop"/>
-                </notations>
-            </note>
-            <note default-y="-10.00" default-x="181.99">
-                <pitch>
-                    <step>D</step>
-                    <octave>5</octave>
-                </pitch>
-                <duration>3</duration>
-                <voice>1</voice>
-                <type>eighth</type>
-                <stem>down</stem>
-                <beam number="1">end</beam>
-                <lyric number="1">
-                    <syllabic>end</syllabic>
-                    <text>ture's</text>
-                </lyric>
-            </note>
-            <harmony print-frame="no">
-                <root>
-                    <root-step>G</root-step>
-                </root>
-                <kind text="">major</kind>
-            </harmony>
-            <note default-y="-20.00" default-x="246.54">
-                <pitch>
-                    <step>B</step>
-                    <octave>4</octave>
-                </pitch>
-                <duration>3</duration>
-                <voice>1</voice>
-                <type>eighth</type>
-                <accidental>natural</accidental>
-                <stem>up</stem>
-                <beam number="1">begin</beam>
-                <lyric number="1">
-                    <syllabic>begin</syllabic>
-                    <text>look</text>
-                </lyric>
-            </note>
-            <note default-y="-30.00" default-x="311.09">
-                <pitch>
-                    <step>G</step>
-                    <octave>4</octave>
-                </pitch>
-                <duration>3</duration>
-                <voice>1</voice>
-                <type>eighth</type>
-                <stem>up</stem>
-                <beam number="1">end</beam>
-                <lyric number="1">
-                    <syllabic>end</syllabic>
-                    <text>ing</text>
-                </lyric>
-            </note>
-        </measure>
-        <measure width="349.76" number="13">
-            <print new-system="yes">
-                <system-layout>
-                    <system-margins>
-                        <left-margin>3.00</left-margin>
-                        <right-margin>0.00</right-margin>
-                    </system-margins>
-                    <system-distance>166.96</system-distance>
-                </system-layout>
-            </print>
-            <harmony print-frame="no">
-                <root>
-                    <root-step>C</root-step>
-                </root>
-                <kind text="">major</kind>
-            </harmony>
-            <note default-y="-5.00" default-x="25.02">
-                <pitch>
-                    <step>E</step>
-                    <octave>5</octave>
-                </pitch>
-                <duration>12</duration>
-                <voice>1</voice>
-                <type>half</type>
-                <stem>down</stem>
-                <lyric number="1">
-                    <syllabic>single</syllabic>
-                    <text>dim,</text>
-                </lyric>
-            </note>
-            <note default-y="-5.00" default-x="194.29">
-                <pitch>
-                    <step>E</step>
-                    <octave>5</octave>
-                </pitch>
-                <duration>3</duration>
-                <voice>1</voice>
-                <type>eighth</type>
-                <stem>down</stem>
-                <beam number="1">begin</beam>
-                <lyric number="1">
-                    <syllabic>single</syllabic>
-                    <text>but</text>
-                </lyric>
-            </note>
-            <note default-y="-15.00" default-x="271.22">
-                <pitch>
-                    <step>C</step>
-                    <octave>5</octave>
-                </pitch>
-                <duration>3</duration>
-                <voice>1</voice>
-                <type>eighth</type>
-                <stem>down</stem>
-                <beam number="1">end</beam>
-                <lyric number="1">
-                    <syllabic>single</syllabic>
-                    <text>these</text>
-                </lyric>
-            </note>
-        </measure>
-        <measure width="440.58" number="14">
-            <note default-y="-30.00" default-x="32.17">
-                <pitch>
-                    <step>G</step>
-                    <octave>4</octave>
-                </pitch>
-                <duration>6</duration>
-                <tie type="start"/>
-                <voice>1</voice>
-                <type>quarter</type>
-                <stem>up</stem>
-                <notations>
-                    <tied type="start"/>
-                </notations>
-                <lyric number="1">
-                    <syllabic>single</syllabic>
-                    <text>things</text>
-                </lyric>
-            </note>
-            <note default-y="-30.00" default-x="148.40">
-                <pitch>
-                    <step>G</step>
-                    <octave>4</octave>
-                </pitch>
-                <duration>3</duration>
-                <tie type="stop"/>
-                <voice>1</voice>
-                <type>eighth</type>
-                <stem>up</stem>
-                <beam number="1">begin</beam>
-                <notations>
-                    <tied type="stop"/>
-                </notations>
-            </note>
-            <note default-y="-25.00" default-x="221.04">
-                <pitch>
-                    <step>A</step>
-                    <octave>4</octave>
-                </pitch>
-                <duration>3</duration>
-                <voice>1</voice>
-                <type>eighth</type>
-                <stem>up</stem>
-                <beam number="1">end</beam>
-                <lyric number="1">
-                    <syllabic>single</syllabic>
-                    <text>your</text>
-                </lyric>
-            </note>
-            <harmony print-frame="no">
-                <root>
-                    <root-step>G</root-step>
-                </root>
-                <kind text="dim">diminished</kind>
-            </harmony>
-            <note default-y="-35.00" default-x="293.69">
-                <pitch>
-                    <step>F</step>
-                    <alter>1</alter>
-                    <octave>4</octave>
-                </pitch>
-                <duration>3</duration>
-                <voice>1</voice>
-                <type>eighth</type>
-                <accidental>sharp</accidental>
-                <stem>up</stem>
-                <beam number="1">begin</beam>
-                <lyric number="1">
-                    <syllabic>single</syllabic>
-                    <text>hearts</text>
-                </lyric>
-            </note>
-            <note default-y="-30.00" default-x="366.33">
-                <pitch>
-                    <step>G</step>
-                    <octave>4</octave>
-                </pitch>
-                <duration>3</duration>
-                <voice>1</voice>
-                <type>eighth</type>
-                <stem>up</stem>
-                <beam number="1">end</beam>
-                <lyric number="1">
-                    <syllabic>single</syllabic>
-                    <text>can</text>
-                </lyric>
-            </note>
-        </measure>
-        <measure width="276.59" number="15">
-            <harmony print-frame="no">
-                <root>
-                    <root-step>G</root-step>
-                </root>
-                <kind text="9">dominant-ninth</kind>
-            </harmony>
-            <note default-y="-10.00" default-x="20.98">
-                <pitch>
-                    <step>D</step>
-                    <octave>5</octave>
-                </pitch>
-                <duration>12</duration>
-                <voice>1</voice>
-                <type>half</type>
-                <stem>down</stem>
-                <lyric number="1">
-                    <syllabic>single</syllabic>
-                    <text>rise</text>
-                </lyric>
-            </note>
-            <harmony print-frame="no">
-                <root>
-                    <root-step>G</root-step>
-                </root>
-                <kind text="7">dominant</kind>
-            </harmony>
-            <note default-y="-5.00" default-x="177.29">
-                <pitch>
-                    <step>E</step>
-                    <octave>5</octave>
-                </pitch>
-                <duration>6</duration>
-                <voice>1</voice>
-                <type>quarter</type>
-                <stem>down</stem>
-                <lyric number="1">
-                    <syllabic>begin</syllabic>
-                    <text>a</text>
-                </lyric>
-            </note>
-        </measure>
-        <measure width="263.41" number="16">
-            <harmony print-frame="no">
-                <root>
-                    <root-step>C</root-step>
-                </root>
-                <kind text="7">dominant</kind>
-            </harmony>
-            <note default-y="-15.00" default-x="26.57">
-                <pitch>
-                    <step>C</step>
-                    <octave>5</octave>
-                </pitch>
-                <duration>18</duration>
-                <voice>1</voice>
-                <type>half</type>
-                <dot/>
-                <stem>down</stem>
-                <lyric number="1">
-                    <syllabic>end</syllabic>
-                    <text>bove</text>
-                </lyric>
-            </note>
-        </measure>
-        <measure width="474.60" number="17">
-            <print new-system="yes">
-                <system-layout>
-                    <system-margins>
-                        <left-margin>3.00</left-margin>
-                        <right-margin>0.00</right-margin>
-                    </system-margins>
-                    <system-distance>166.96</system-distance>
-                </system-layout>
-            </print>
-            <note>
-                <rest/>
-                <duration>6</duration>
-                <voice>1</voice>
-                <type>quarter</type>
-            </note>
-            <harmony print-frame="no">
-                <root>
-                    <root-step>F</root-step>
-                </root>
-                <kind text="">major</kind>
-            </harmony>
-            <note default-y="-25.00" default-x="125.12">
-                <pitch>
-                    <step>A</step>
-                    <octave>4</octave>
-                </pitch>
-                <duration>2</duration>
-                <voice>1</voice>
-                <type>eighth</type>
-                <time-modification>
-                    <actual-notes>3</actual-notes>
-                    <normal-notes>2</normal-notes>
-                </time-modification>
-                <stem>down</stem>
-                <beam number="1">begin</beam>
-                <notations>
-                    <tuplet type="start" bracket="no"/>
-                </notations>
-                <lyric number="1">
-                    <syllabic>single</syllabic>
-                    <text>Once</text>
-                </lyric>
-            </note>
-            <note default-y="-20.00" default-x="183.10">
-                <pitch>
-                    <step>B</step>
-                    <alter>-1</alter>
-                    <octave>4</octave>
-                </pitch>
-                <duration>2</duration>
-                <voice>1</voice>
-                <type>eighth</type>
-                <time-modification>
-                    <actual-notes>3</actual-notes>
-                    <normal-notes>2</normal-notes>
-                </time-modification>
-                <stem>down</stem>
-                <beam number="1">continue</beam>
-                <lyric number="1">
-                    <syllabic>single</syllabic>
-                    <text>in</text>
-                </lyric>
-            </note>
-            <note default-y="-15.00" default-x="241.08">
-                <pitch>
-                    <step>C</step>
-                    <octave>5</octave>
-                </pitch>
-                <duration>2</duration>
-                <voice>1</voice>
-                <type>eighth</type>
-                <time-modification>
-                    <actual-notes>3</actual-notes>
-                    <normal-notes>2</normal-notes>
-                </time-modification>
-                <stem>down</stem>
-                <beam number="1">end</beam>
-                <notations>
-                    <tuplet type="stop"/>
-                </notations>
-                <lyric number="1">
-                    <syllabic>single</syllabic>
-                    <text>a</text>
-                </lyric>
-            </note>
-            <harmony print-frame="no">
-                <root>
-                    <root-step>B</root-step>
-                    <root-alter>-1</root-alter>
-                </root>
-                <kind text="Maj7">major-seventh</kind>
-            </harmony>
-            <note default-y="-10.00" default-x="299.06">
-                <pitch>
-                    <step>D</step>
-                    <octave>5</octave>
-                </pitch>
-                <duration>2</duration>
-                <voice>1</voice>
-                <type>eighth</type>
-                <time-modification>
-                    <actual-notes>3</actual-notes>
-                    <normal-notes>2</normal-notes>
-                </time-modification>
-                <stem>down</stem>
-                <beam number="1">begin</beam>
-                <notations>
-                    <tuplet type="start" bracket="no"/>
-                </notations>
-                <lyric number="1">
-                    <syllabic>single</syllabic>
-                    <text>while</text>
-                </lyric>
-            </note>
-            <note default-y="-15.00" default-x="357.04">
-                <pitch>
-                    <step>C</step>
-                    <octave>5</octave>
-                </pitch>
-                <duration>2</duration>
-                <voice>1</voice>
-                <type>eighth</type>
-                <time-modification>
-                    <actual-notes>3</actual-notes>
-                    <normal-notes>2</normal-notes>
-                </time-modification>
-                <stem>down</stem>
-                <beam number="1">continue</beam>
-                <lyric number="1">
-                    <syllabic>single</syllabic>
-                    <text>he</text>
-                </lyric>
-            </note>
-            <note default-y="-20.00" default-x="415.02">
-                <pitch>
-                    <step>B</step>
-                    <alter>-1</alter>
-                    <octave>4</octave>
-                </pitch>
-                <duration>2</duration>
-                <voice>1</voice>
-                <type>eighth</type>
-                <time-modification>
-                    <actual-notes>3</actual-notes>
-                    <normal-notes>2</normal-notes>
-                </time-modification>
-                <stem>down</stem>
-                <beam number="1">end</beam>
-                <notations>
-                    <tuplet type="stop"/>
-                </notations>
-                <lyric number="1">
-                    <syllabic>single</syllabic>
-                    <text>won't</text>
-                </lyric>
-            </note>
-        </measure>
-        <measure width="307.49" number="18">
-            <harmony print-frame="no">
-                <root>
-                    <root-step>F</root-step>
-                </root>
-                <kind text="Maj7">major-seventh</kind>
-            </harmony>
-            <note default-y="-25.00" default-x="20.97">
-                <pitch>
-                    <step>A</step>
-                    <octave>4</octave>
-                </pitch>
-                <duration>12</duration>
-                <voice>1</voice>
-                <type>half</type>
-                <stem>up</stem>
-                <lyric number="1">
-                    <syllabic>single</syllabic>
-                    <text>call</text>
-                </lyric>
-            </note>
-            <note default-y="-30.00" default-x="170.21">
-                <pitch>
-                    <step>G</step>
-                    <octave>4</octave>
-                </pitch>
-                <duration>3</duration>
-                <voice>1</voice>
-                <type>eighth</type>
-                <stem>up</stem>
-                <beam number="1">begin</beam>
-                <lyric number="1">
-                    <syllabic>single</syllabic>
-                    <text>but</text>
-                </lyric>
-            </note>
-            <note default-y="-40.00" default-x="238.05">
-                <pitch>
-                    <step>E</step>
-                    <octave>4</octave>
-                </pitch>
-                <duration>3</duration>
-                <voice>1</voice>
-                <type>eighth</type>
-                <stem>up</stem>
-                <beam number="1">end</beam>
-                <lyric number="1">
-                    <syllabic>single</syllabic>
-                    <text>it's</text>
-                </lyric>
-            </note>
-        </measure>
-        <measure width="293.27" number="19">
-            <harmony print-frame="no">
-                <root>
-                    <root-step>B</root-step>
-                    <root-alter>-1</root-alter>
-                </root>
-                <kind text="">major</kind>
-            </harmony>
-            <note default-y="-45.00" default-x="16.01">
-                <pitch>
-                    <step>D</step>
-                    <octave>4</octave>
-                </pitch>
-                <duration>12</duration>
-                <voice>1</voice>
-                <type>half</type>
-                <stem>up</stem>
-                <lyric number="1">
-                    <syllabic>single</syllabic>
-                    <text>all</text>
-                </lyric>
-            </note>
-            <harmony print-frame="no">
-                <root>
-                    <root-step>C</root-step>
-                </root>
-                <kind text="7">dominant</kind>
-            </harmony>
-            <note default-y="-30.00" default-x="160.40">
-                <pitch>
-                    <step>G</step>
-                    <octave>4</octave>
-                </pitch>
-                <duration>3</duration>
-                <voice>1</voice>
-                <type>eighth</type>
-                <stem>up</stem>
-                <beam number="1">begin</beam>
-                <lyric number="1">
-                    <syllabic>single</syllabic>
-                    <text>in</text>
-                </lyric>
-            </note>
-            <note default-y="-40.00" default-x="226.04">
-                <pitch>
-                    <step>E</step>
-                    <octave>4</octave>
-                </pitch>
-                <duration>3</duration>
-                <voice>1</voice>
-                <type>eighth</type>
-                <stem>up</stem>
-                <beam number="1">end</beam>
-                <lyric number="1">
-                    <syllabic>single</syllabic>
-                    <text>the</text>
-                </lyric>
-            </note>
-        </measure>
-        <measure width="254.97" number="20">
-            <harmony print-frame="no">
-                <root>
-                    <root-step>F</root-step>
-                </root>
-                <kind text="">major</kind>
-            </harmony>
-            <note default-y="-50.00" default-x="29.04">
-                <pitch>
-                    <step>C</step>
-                    <octave>4</octave>
-                </pitch>
-                <duration>18</duration>
-                <voice>1</voice>
-                <type>half</type>
-                <dot/>
-                <stem>up</stem>
-                <lyric number="1">
-                    <syllabic>single</syllabic>
-                    <text>game</text>
-                </lyric>
-            </note>
-        </measure>
-        <measure width="414.54" number="21">
-            <print new-system="yes">
-                <system-layout>
-                    <system-margins>
-                        <left-margin>3.00</left-margin>
-                        <right-margin>0.00</right-margin>
-                    </system-margins>
-                    <system-distance>166.96</system-distance>
-                </system-layout>
-            </print>
-            <note>
-                <rest/>
-                <duration>6</duration>
-                <voice>1</voice>
-                <type>quarter</type>
-            </note>
-            <note default-y="-25.00" default-x="110.38">
-                <pitch>
-                    <step>A</step>
-                    <octave>4</octave>
-                </pitch>
-                <duration>2</duration>
-                <voice>1</voice>
-                <type>eighth</type>
-                <time-modification>
-                    <actual-notes>3</actual-notes>
-                    <normal-notes>2</normal-notes>
-                </time-modification>
-                <stem>down</stem>
-                <beam number="1">begin</beam>
-                <notations>
-                    <tuplet type="start" bracket="no"/>
-                </notations>
-                <lyric number="1">
-                    <syllabic>single</syllabic>
-                    <text>Soon</text>
-                </lyric>
-            </note>
-            <note default-y="-20.00" default-x="160.81">
-                <pitch>
-                    <step>B</step>
-                    <alter>-1</alter>
-                    <octave>4</octave>
-                </pitch>
-                <duration>2</duration>
-                <voice>1</voice>
-                <type>eighth</type>
-                <time-modification>
-                    <actual-notes>3</actual-notes>
-                    <normal-notes>2</normal-notes>
-                </time-modification>
-                <stem>down</stem>
-                <beam number="1">continue</beam>
-                <lyric number="1">
-                    <syllabic>single</syllabic>
-                    <text>he'll</text>
-                </lyric>
-            </note>
-            <note default-y="-15.00" default-x="211.23">
-                <pitch>
-                    <step>C</step>
-                    <octave>5</octave>
-                </pitch>
-                <duration>2</duration>
-                <voice>1</voice>
-                <type>eighth</type>
-                <time-modification>
-                    <actual-notes>3</actual-notes>
-                    <normal-notes>2</normal-notes>
-                </time-modification>
-                <stem>down</stem>
-                <beam number="1">end</beam>
-                <notations>
-                    <tuplet type="stop"/>
-                </notations>
-                <lyric number="1">
-                    <syllabic>single</syllabic>
-                    <text>be</text>
-                </lyric>
-            </note>
-            <harmony print-frame="no">
-                <root>
-                    <root-step>B</root-step>
-                    <root-alter>-1</root-alter>
-                </root>
-                <kind text="Maj7">major-seventh</kind>
-            </harmony>
-            <note default-y="-10.00" default-x="261.66">
-                <pitch>
-                    <step>D</step>
-                    <octave>5</octave>
-                </pitch>
-                <duration>2</duration>
-                <voice>1</voice>
-                <type>eighth</type>
-                <time-modification>
-                    <actual-notes>3</actual-notes>
-                    <normal-notes>2</normal-notes>
-                </time-modification>
-                <stem>down</stem>
-                <beam number="1">begin</beam>
-                <notations>
-                    <tuplet type="start" bracket="no"/>
-                </notations>
-                <lyric number="1">
-                    <syllabic>single</syllabic>
-                    <text>there</text>
-                </lyric>
-            </note>
-            <note default-y="-15.00" default-x="312.08">
-                <pitch>
-                    <step>C</step>
-                    <octave>5</octave>
-                </pitch>
-                <duration>2</duration>
-                <voice>1</voice>
-                <type>eighth</type>
-                <time-modification>
-                    <actual-notes>3</actual-notes>
-                    <normal-notes>2</normal-notes>
-                </time-modification>
-                <stem>down</stem>
-                <beam number="1">continue</beam>
-                <lyric number="1">
-                    <syllabic>single</syllabic>
-                    <text>at</text>
-                </lyric>
-            </note>
-            <note default-y="-20.00" default-x="362.51">
-                <pitch>
-                    <step>B</step>
-                    <alter>-1</alter>
-                    <octave>4</octave>
-                </pitch>
-                <duration>2</duration>
-                <voice>1</voice>
-                <type>eighth</type>
-                <time-modification>
-                    <actual-notes>3</actual-notes>
-                    <normal-notes>2</normal-notes>
-                </time-modification>
-                <stem>down</stem>
-                <beam number="1">end</beam>
-                <notations>
-                    <tuplet type="stop"/>
-                </notations>
-                <lyric number="1">
-                    <syllabic>single</syllabic>
-                    <text>your</text>
-                </lyric>
-            </note>
-        </measure>
-        <measure width="247.94" number="22">
-            <harmony print-frame="no">
-                <root>
-                    <root-step>F</root-step>
-                </root>
-                <kind text="Maj7">major-seventh</kind>
-            </harmony>
-            <note default-y="-25.00" default-x="22.84">
-                <pitch>
-                    <step>A</step>
-                    <octave>4</octave>
-                </pitch>
-                <duration>12</duration>
-                <voice>1</voice>
-                <type>half</type>
-                <stem>up</stem>
-                <lyric number="1">
-                    <syllabic>single</syllabic>
-                    <text>side</text>
-                </lyric>
-            </note>
-            <note default-y="-15.00" default-x="139.91">
-                <pitch>
-                    <step>C</step>
-                    <octave>5</octave>
-                </pitch>
-                <duration>3</duration>
-                <voice>1</voice>
-                <type>eighth</type>
-                <stem>up</stem>
-                <beam number="1">begin</beam>
-                <lyric number="1">
-                    <syllabic>single</syllabic>
-                    <text>with</text>
-                </lyric>
-            </note>
-            <note default-y="-25.00" default-x="193.12">
-                <pitch>
-                    <step>A</step>
-                    <octave>4</octave>
-                </pitch>
-                <duration>3</duration>
-                <voice>1</voice>
-                <type>eighth</type>
-                <stem>up</stem>
-                <beam number="1">end</beam>
-                <lyric number="1">
-                    <syllabic>single</syllabic>
-                    <text>a</text>
-                </lyric>
-            </note>
-        </measure>
-        <measure width="232.26" number="23">
-            <harmony print-frame="no">
-                <root>
-                    <root-step>B</root-step>
-                    <root-alter>-1</root-alter>
-                </root>
-                <kind text="">major</kind>
-            </harmony>
-            <note default-y="-10.00" default-x="30.28">
-                <pitch>
-                    <step>D</step>
-                    <octave>5</octave>
-                </pitch>
-                <duration>12</duration>
-                <voice>1</voice>
-                <type>half</type>
-                <stem>down</stem>
-                <lyric number="1">
-                    <syllabic>single</syllabic>
-                    <text>sweet</text>
-                </lyric>
-            </note>
-            <note default-y="-35.00" default-x="153.59">
-                <pitch>
-                    <step>F</step>
-                    <octave>4</octave>
-                </pitch>
-                <duration>6</duration>
-                <voice>1</voice>
-                <type>quarter</type>
-                <stem>up</stem>
-                <lyric number="1">
-                    <syllabic>begin</syllabic>
-                    <text>bou</text>
-                </lyric>
-            </note>
-        </measure>
-        <measure width="184.44" number="24">
-            <harmony print-frame="no">
-                <root>
-                    <root-step>F</root-step>
-                </root>
-                <kind text="">major</kind>
-            </harmony>
-            <note default-y="-25.00" default-x="26.88">
-                <pitch>
-                    <step>A</step>
-                    <octave>4</octave>
-                </pitch>
-                <duration>18</duration>
-                <tie type="start"/>
-                <voice>1</voice>
-                <type>half</type>
-                <dot/>
-                <stem>up</stem>
-                <notations>
-                    <tied type="start"/>
-                </notations>
-                <lyric number="1">
-                    <syllabic>end</syllabic>
-                    <text>quet,</text>
-                </lyric>
-            </note>
-        </measure>
-        <measure width="251.16" number="25">
-            <note default-y="-25.00" default-x="12.00">
-                <pitch>
-                    <step>A</step>
-                    <octave>4</octave>
-                </pitch>
-                <duration>12</duration>
-                <tie type="stop"/>
-                <voice>1</voice>
-                <type>half</type>
-                <stem>up</stem>
-                <notations>
-                    <tied type="stop"/>
-                </notations>
-            </note>
-            <note default-y="-25.00" default-x="136.44">
-                <pitch>
-                    <step>A</step>
-                    <octave>4</octave>
-                </pitch>
-                <duration>3</duration>
-                <voice>1</voice>
-                <type>eighth</type>
-                <stem>up</stem>
-                <beam number="1">begin</beam>
-                <lyric number="1">
-                    <syllabic>single</syllabic>
-                    <text>And</text>
-                </lyric>
-            </note>
-            <note default-y="-20.00" default-x="193.00">
-                <pitch>
-                    <step>B</step>
-                    <alter>-1</alter>
-                    <octave>4</octave>
-                </pitch>
-                <duration>3</duration>
-                <voice>1</voice>
-                <type>eighth</type>
-                <stem>up</stem>
-                <beam number="1">end</beam>
-                <lyric number="1">
-                    <syllabic>single</syllabic>
-                    <text>he'll</text>
-                </lyric>
-            </note>
-        </measure>
-        <measure width="216.00" number="26">
-            <print new-system="yes">
-                <system-layout>
-                    <system-margins>
-                        <left-margin>3.00</left-margin>
-                        <right-margin>-0.00</right-margin>
-                    </system-margins>
-                    <system-distance>166.96</system-distance>
-                </system-layout>
-            </print>
-            <note default-y="-15.00" default-x="22.23">
-                <pitch>
-                    <step>C</step>
-                    <octave>5</octave>
-                </pitch>
-                <duration>12</duration>
-                <voice>1</voice>
-                <type>half</type>
-                <stem>down</stem>
-                <lyric number="1">
-                    <syllabic>single</syllabic>
-                    <text>kiss</text>
-                </lyric>
-            </note>
-            <harmony print-frame="no">
-                <root>
-                    <root-step>A</root-step>
-                </root>
-                <kind text="m">minor</kind>
-            </harmony>
-            <note default-y="-50.00" default-x="140.49">
-                <pitch>
-                    <step>C</step>
-                    <octave>4</octave>
-                </pitch>
-                <duration>6</duration>
-                <voice>1</voice>
-                <type>quarter</type>
-                <stem>up</stem>
-                <lyric number="1">
-                    <syllabic>single</syllabic>
-                    <text>tour</text>
-                </lyric>
-            </note>
-        </measure>
-        <measure width="239.09" number="27">
-            <harmony print-frame="no">
-                <root>
-                    <root-step>D</root-step>
-                </root>
-                <kind text="m">minor</kind>
-            </harmony>
-            <note default-y="-45.00" default-x="20.99">
-                <pitch>
-                    <step>D</step>
-                    <octave>4</octave>
-                </pitch>
-                <duration>12</duration>
-                <voice>1</voice>
-                <type>half</type>
-                <stem>up</stem>
-                <lyric number="1">
-                    <syllabic>single</syllabic>
-                    <text>lips</text>
-                </lyric>
-            </note>
-            <note default-y="-25.00" default-x="134.39">
-                <pitch>
-                    <step>A</step>
-                    <octave>4</octave>
-                </pitch>
-                <duration>3</duration>
-                <voice>1</voice>
-                <type>eighth</type>
-                <stem>up</stem>
-                <beam number="1">begin</beam>
-                <lyric number="1">
-                    <syllabic>single</syllabic>
-                    <text>and</text>
-                </lyric>
-            </note>
-            <note default-y="-15.00" default-x="185.94">
-                <pitch>
-                    <step>C</step>
-                    <octave>5</octave>
-                </pitch>
-                <duration>3</duration>
-                <voice>1</voice>
-                <type>eighth</type>
-                <stem>up</stem>
-                <beam number="1">end</beam>
-                <lyric number="1">
-                    <syllabic>begin</syllabic>
-                    <text>ca</text>
-                </lyric>
-            </note>
-        </measure>
-        <measure width="371.27" number="28">
-            <harmony print-frame="no">
-                <root>
-                    <root-step>G</root-step>
-                </root>
-                <kind text="9">dominant-ninth</kind>
-            </harmony>
-            <note default-y="-5.00" default-x="22.23">
-                <pitch>
-                    <step>E</step>
-                    <octave>5</octave>
-                </pitch>
-                <duration>3</duration>
-                <voice>1</voice>
-                <type>eighth</type>
-                <stem>down</stem>
-                <beam number="1">begin</beam>
-                <lyric number="1">
-                    <syllabic>end</syllabic>
-                    <text>ress</text>
-                </lyric>
-            </note>
-            <note default-y="-10.00" default-x="80.13">
-                <pitch>
-                    <step>D</step>
-                    <octave>5</octave>
-                </pitch>
-                <duration>3</duration>
-                <voice>1</voice>
-                <type>eighth</type>
-                <stem>down</stem>
-                <beam number="1">end</beam>
-                <lyric number="1">
-                    <syllabic>single</syllabic>
-                    <text>your</text>
-                </lyric>
-            </note>
-            <note default-y="-15.00" default-x="138.04">
-                <pitch>
-                    <step>C</step>
-                    <octave>5</octave>
-                </pitch>
-                <duration>3</duration>
-                <voice>1</voice>
-                <type>eighth</type>
-                <stem>up</stem>
-                <beam number="1">begin</beam>
-                <lyric number="1">
-                    <syllabic>begin</syllabic>
-                    <text>wai</text>
-                </lyric>
-            </note>
-            <note default-y="-25.00" default-x="195.95">
-                <pitch>
-                    <step>A</step>
-                    <octave>4</octave>
-                </pitch>
-                <duration>3</duration>
-                <voice>1</voice>
-                <type>eighth</type>
-                <stem>up</stem>
-                <beam number="1">end</beam>
-                <lyric number="1">
-                    <syllabic>end</syllabic>
-                    <text>ting</text>
-                </lyric>
-            </note>
-            <note default-y="-30.00" default-x="253.85">
-                <pitch>
-                    <step>G</step>
-                    <octave>4</octave>
-                </pitch>
-                <duration>3</duration>
-                <voice>1</voice>
-                <type>eighth</type>
-                <stem>up</stem>
-                <beam number="1">begin</beam>
-                <lyric number="1">
-                    <syllabic>begin</syllabic>
-                    <text>fin</text>
-                </lyric>
-            </note>
-            <note default-y="-35.00" default-x="311.76">
-                <pitch>
-                    <step>F</step>
-                    <octave>4</octave>
-                </pitch>
-                <duration>3</duration>
-                <voice>1</voice>
-                <type>eighth</type>
-                <stem>up</stem>
-                <beam number="1">end</beam>
-                <lyric number="1">
-                    <syllabic>end</syllabic>
-                    <text>ger</text>
-                </lyric>
-            </note>
-        </measure>
-        <measure width="270.65" number="29">
-            <harmony print-frame="no">
-                <root>
-                    <root-step>G</root-step>
-                </root>
-                <kind text="7">dominant</kind>
-            </harmony>
-            <note default-y="-45.00" default-x="24.09">
-                <pitch>
-                    <step>D</step>
-                    <octave>4</octave>
-                </pitch>
-                <duration>12</duration>
-                <voice>1</voice>
-                <type>half</type>
-                <stem>up</stem>
-                <lyric number="1">
-                    <syllabic>single</syllabic>
-                    <text>tips;</text>
-                </lyric>
-            </note>
-            <note default-y="-25.00" default-x="152.40">
-                <pitch>
-                    <step>A</step>
-                    <octave>4</octave>
-                </pitch>
-                <duration>3</duration>
-                <voice>1</voice>
-                <type>eighth</type>
-                <stem>up</stem>
-                <beam number="1">begin</beam>
-                <lyric number="1">
-                    <syllabic>single</syllabic>
-                    <text>And</text>
-                </lyric>
-            </note>
-            <note default-y="-20.00" default-x="210.72">
-                <pitch>
-                    <step>B</step>
-                    <alter>-1</alter>
-                    <octave>4</octave>
-                </pitch>
-                <duration>3</duration>
-                <voice>1</voice>
-                <type>eighth</type>
-                <stem>up</stem>
-                <beam number="1">end</beam>
-                <lyric number="1">
-                    <syllabic>single</syllabic>
-                    <text>your</text>
-                </lyric>
-            </note>
-        </measure>
-        <measure width="233.33" number="30">
-            <harmony print-frame="no">
-                <root>
-                    <root-step>G</root-step>
-                </root>
-                <kind text="m7">minor-seventh</kind>
-            </harmony>
-            <note default-y="-15.00" default-x="31.53">
-                <pitch>
-                    <step>C</step>
-                    <octave>5</octave>
-                </pitch>
-                <duration>12</duration>
-                <voice>1</voice>
-                <type>half</type>
-                <stem>down</stem>
-                <lyric number="1">
-                    <syllabic>single</syllabic>
-                    <text>hearts</text>
-                </lyric>
-            </note>
-            <note default-y="-15.00" default-x="154.73">
-                <pitch>
-                    <step>C</step>
-                    <octave>5</octave>
-                </pitch>
-                <duration>6</duration>
-                <voice>1</voice>
-                <type>quarter</type>
-                <stem>down</stem>
-                <lyric number="1">
-                    <syllabic>single</syllabic>
-                    <text>will</text>
-                </lyric>
-            </note>
-        </measure>
-        <measure width="442.90" number="31">
-            <print new-system="yes">
-                <system-layout>
-                    <system-margins>
-                        <left-margin>3.00</left-margin>
-                        <right-margin>0.00</right-margin>
-                    </system-margins>
-                    <system-distance>166.96</system-distance>
-                </system-layout>
-            </print>
-            <harmony print-frame="no">
-                <root>
-                    <root-step>C</root-step>
-                </root>
-                <kind text="7">dominant</kind>
-            </harmony>
-            <note default-y="-10.00" default-x="17.25">
-                <pitch>
-                    <step>D</step>
-                    <octave>5</octave>
-                </pitch>
-                <duration>12</duration>
-                <voice>1</voice>
-                <type>half</type>
-                <stem>down</stem>
-                <lyric number="1">
-                    <syllabic>single</syllabic>
-                    <text>fly</text>
-                </lyric>
-            </note>
-            <note default-y="-15.00" default-x="278.21">
-                <pitch>
-                    <step>C</step>
-                    <octave>5</octave>
-                </pitch>
-                <duration>6</duration>
-                <voice>1</voice>
-                <type>quarter</type>
-                <stem>down</stem>
-                <lyric number="1">
-                    <syllabic>begin</syllabic>
-                    <text>a</text>
-                </lyric>
-            </note>
-        </measure>
-        <measure width="435.36" number="32">
-            <direction>
-                <direction-type>
-                    <words default-y="100">F</words>
-                </direction-type>
-            </direction>
-            <note default-y="-35.00" default-x="25.57">
-                <pitch>
-                    <step>F</step>
-                    <octave>4</octave>
-                </pitch>
-                <duration>18</duration>
-                <tie type="start"/>
-                <voice>1</voice>
-                <type>half</type>
-                <dot/>
-                <stem>up</stem>
-                <notations>
-                    <tied type="start"/>
-                </notations>
-                <lyric number="1">
-                    <syllabic>end</syllabic>
-                    <text>way.</text>
-                </lyric>
-            </note>
-        </measure>
-        <measure width="452.07" number="33">
-            <note default-y="-35.00" default-x="12.00">
-                <pitch>
-                    <step>F</step>
-                    <octave>4</octave>
-                </pitch>
-                <duration>6</duration>
-                <tie type="stop"/>
-                <voice>1</voice>
-                <type>quarter</type>
-                <stem>up</stem>
-                <notations>
-                    <tied type="stop"/>
-                </notations>
-            </note>
-            <note>
-                <rest/>
-                <duration>6</duration>
-                <voice>1</voice>
-                <type>quarter</type>
-            </note>
-            <note>
-                <rest/>
-                <duration>6</duration>
-                <voice>1</voice>
-                <type>quarter</type>
-            </note>
-            <barline location="right">
-                <bar-style>light-heavy</bar-style>
-            </barline>
-        </measure>
-    </part>
+  <work>
+    <work-number></work-number>
+    <work-title></work-title>
+  </work>
+  <movement-number></movement-number>
+  <movement-title>It's All In The Game</movement-title>
+  <identification>
+    <creator type="composer">&amp; Nobel Prize Winner), Charles Gate Dawes (V.P. of U.S.A.</creator>
+    <creator type="poet">Carl Sigman</creator>
+    <rights>All Rights Reserved</rights>
+    <encoding>
+      <software>MuseScore 1.2</software>
+      <encoding-date>2012-04-30</encoding-date>
+      <software>ProxyMusic 2.0 c</software>
+    </encoding>
+    <source>http://wikifonia.org/node/15933/revisions/21292/view</source>
+  </identification>
+  <defaults>
+    <scaling>
+      <millimeters>5.7</millimeters>
+      <tenths>40</tenths>
+    </scaling>
+    <page-layout>
+      <page-height>2084.21</page-height>
+      <page-width>1473.68</page-width>
+      <page-margins type="both">
+        <left-margin>70.1754</left-margin>
+        <right-margin>70.1754</right-margin>
+        <top-margin>70.1754</top-margin>
+        <bottom-margin>140.351</bottom-margin>
+      </page-margins>
+    </page-layout>
+  </defaults>
+  <credit page="1">
+    <credit-words font-size="24" default-y="2014.04" default-x="736.842" justify="center" valign="top">It's All In The Game</credit-words>
+  </credit>
+  <credit page="1">
+    <credit-words font-size="12" default-y="1951.17" default-x="1403.51" justify="right" valign="top">Charles Gate Dawes</credit-words>
+  </credit>
+  <credit page="1">
+    <credit-words font-size="12" default-y="1951.17" default-x="70.1754" justify="left" valign="top">Carl Sigman</credit-words>
+  </credit>
+  <part-list>
+    <score-part id="P1">
+      <part-name></part-name>
+      <score-instrument id="P1-I3">
+        <instrument-name></instrument-name>
+      </score-instrument>
+      <midi-instrument id="P1-I3">
+        <midi-channel>1</midi-channel>
+        <midi-program>41</midi-program>
+        <volume>78.7402</volume>
+        <pan>0</pan>
+      </midi-instrument>
+    </score-part>
+  </part-list>
+  <part id="P1">
+    <measure width="492.75" number="1">
+      <print page-number="1">
+        <system-layout>
+          <system-margins>
+            <left-margin>3.00</left-margin>
+            <right-margin>0.00</right-margin>
+          </system-margins>
+          <top-system-distance>302.20</top-system-distance>
+        </system-layout>
+      </print>
+      <attributes>
+        <divisions>6</divisions>
+        <key>
+          <fifths>-1</fifths>
+          <mode>major</mode>
+        </key>
+        <time>
+          <beats>3</beats>
+          <beat-type>4</beat-type>
+        </time>
+        <clef>
+          <sign>G</sign>
+          <line>2</line>
+        </clef>
+      </attributes>
+      <note>
+        <rest />
+        <duration>6</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+      </note>
+      <note default-y="-25.00" default-x="186.28">
+        <pitch>
+          <step>A</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>eighth</type>
+        <time-modification>
+          <actual-notes>3</actual-notes>
+          <normal-notes>2</normal-notes>
+        </time-modification>
+        <stem>down</stem>
+        <beam number="1">begin</beam>
+        <notations>
+          <tuplet type="start" bracket="no" />
+        </notations>
+        <lyric number="1" name="verse1">
+          <syllabic>single</syllabic>
+          <text>1.</text>
+          <elision> </elision>
+          <syllabic>begin</syllabic>
+          <text>Ma</text>
+        </lyric>
+        <lyric number="2" name="verse2">
+          <syllabic>begin</syllabic>
+          <text>Mo</text>
+        </lyric>
+      </note>
+      <note default-y="-20.00" default-x="237.10">
+        <pitch>
+          <step>B</step>
+          <alter>-1</alter>
+          <octave>4</octave>
+        </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>eighth</type>
+        <time-modification>
+          <actual-notes>3</actual-notes>
+          <normal-notes>2</normal-notes>
+        </time-modification>
+        <stem>down</stem>
+        <beam number="1">continue</beam>
+        <lyric number="1" name="verse1">
+          <syllabic>end</syllabic>
+          <text>ny</text>
+        </lyric>
+        <lyric number="2" name="verse2">
+          <syllabic>end</syllabic>
+          <text>re ...</text>
+        </lyric>
+      </note>
+      <note default-y="-15.00" default-x="287.91">
+        <pitch>
+          <step>C</step>
+          <octave>5</octave>
+        </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>eighth</type>
+        <time-modification>
+          <actual-notes>3</actual-notes>
+          <normal-notes>2</normal-notes>
+        </time-modification>
+        <stem>down</stem>
+        <beam number="1">end</beam>
+        <notations>
+          <tuplet type="stop" />
+        </notations>
+        <lyric number="1" name="verse1">
+          <syllabic>single</syllabic>
+          <text>a</text>
+        </lyric>
+      </note>
+      <note default-y="-10.00" default-x="338.72">
+        <pitch>
+          <step>D</step>
+          <octave>5</octave>
+        </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>eighth</type>
+        <time-modification>
+          <actual-notes>3</actual-notes>
+          <normal-notes>2</normal-notes>
+        </time-modification>
+        <stem>down</stem>
+        <beam number="1">begin</beam>
+        <notations>
+          <tuplet type="start" bracket="no" />
+        </notations>
+        <lyric number="1" name="verse1">
+          <syllabic>single</syllabic>
+          <text>tear</text>
+        </lyric>
+      </note>
+      <note default-y="-15.00" default-x="389.53">
+        <pitch>
+          <step>C</step>
+          <octave>5</octave>
+        </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>eighth</type>
+        <time-modification>
+          <actual-notes>3</actual-notes>
+          <normal-notes>2</normal-notes>
+        </time-modification>
+        <stem>down</stem>
+        <beam number="1">continue</beam>
+        <lyric number="1" name="verse1">
+          <syllabic>single</syllabic>
+          <text>has</text>
+        </lyric>
+      </note>
+      <note default-y="-20.00" default-x="440.34">
+        <pitch>
+          <step>B</step>
+          <alter>-1</alter>
+          <octave>4</octave>
+        </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>eighth</type>
+        <time-modification>
+          <actual-notes>3</actual-notes>
+          <normal-notes>2</normal-notes>
+        </time-modification>
+        <stem>down</stem>
+        <beam number="1">end</beam>
+        <notations>
+          <tuplet type="stop" />
+        </notations>
+        <lyric number="1" name="verse1">
+          <syllabic>single</syllabic>
+          <text>to</text>
+        </lyric>
+      </note>
+    </measure>
+    <measure width="299.79" number="2">
+      <harmony print-frame="no">
+        <root>
+          <root-step>F</root-step>
+        </root>
+        <kind text="">major</kind>
+      </harmony>
+      <note default-y="-25.00" default-x="19.73">
+        <pitch>
+          <step>A</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>12</duration>
+        <voice>1</voice>
+        <type>half</type>
+        <stem>up</stem>
+        <lyric number="1" name="verse1">
+          <syllabic>single</syllabic>
+          <text>fall</text>
+        </lyric>
+      </note>
+      <note default-y="-30.00" default-x="165.59">
+        <pitch>
+          <step>G</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>3</duration>
+        <voice>1</voice>
+        <type>eighth</type>
+        <stem>up</stem>
+        <beam number="1">begin</beam>
+        <lyric number="1" name="verse1">
+          <syllabic>single</syllabic>
+          <text>but</text>
+        </lyric>
+      </note>
+      <note default-y="-40.00" default-x="231.89">
+        <pitch>
+          <step>E</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>3</duration>
+        <voice>1</voice>
+        <type>eighth</type>
+        <stem>up</stem>
+        <beam number="1">end</beam>
+        <lyric number="1" name="verse1">
+          <syllabic>single</syllabic>
+          <text>it's</text>
+        </lyric>
+      </note>
+    </measure>
+    <measure width="288.05" number="3">
+      <harmony print-frame="no">
+        <root>
+          <root-step>B</root-step>
+          <root-alter>-1</root-alter>
+        </root>
+        <kind text="">major</kind>
+      </harmony>
+      <note default-y="-45.00" default-x="16.01">
+        <pitch>
+          <step>D</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>12</duration>
+        <voice>1</voice>
+        <type>half</type>
+        <stem>up</stem>
+        <lyric number="1" name="verse1">
+          <syllabic>single</syllabic>
+          <text>all</text>
+        </lyric>
+      </note>
+      <harmony print-frame="no">
+        <root>
+          <root-step>C</root-step>
+        </root>
+        <kind text="7">dominant</kind>
+      </harmony>
+      <note default-y="-30.00" default-x="157.67">
+        <pitch>
+          <step>G</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>3</duration>
+        <voice>1</voice>
+        <type>eighth</type>
+        <stem>up</stem>
+        <beam number="1">begin</beam>
+        <lyric number="1" name="verse1">
+          <syllabic>single</syllabic>
+          <text>in</text>
+        </lyric>
+      </note>
+      <note default-y="-40.00" default-x="222.06">
+        <pitch>
+          <step>E</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>3</duration>
+        <voice>1</voice>
+        <type>eighth</type>
+        <stem>up</stem>
+        <beam number="1">end</beam>
+        <lyric number="1" name="verse1">
+          <syllabic>single</syllabic>
+          <text>the</text>
+        </lyric>
+      </note>
+    </measure>
+    <measure width="249.75" number="4">
+      <harmony print-frame="no">
+        <root>
+          <root-step>F</root-step>
+        </root>
+        <kind text="">major</kind>
+      </harmony>
+      <note default-y="-50.00" default-x="29.04">
+        <pitch>
+          <step>C</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>18</duration>
+        <voice>1</voice>
+        <type>half</type>
+        <dot />
+        <stem>up</stem>
+        <lyric number="1" name="verse1">
+          <syllabic>single</syllabic>
+          <text>game</text>
+        </lyric>
+      </note>
+    </measure>
+    <measure width="444.40" number="5">
+      <print new-system="yes">
+        <system-layout>
+          <system-margins>
+            <left-margin>3.00</left-margin>
+            <right-margin>0.00</right-margin>
+          </system-margins>
+          <system-distance>166.96</system-distance>
+        </system-layout>
+      </print>
+      <note>
+        <rest />
+        <duration>6</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+      </note>
+      <note default-y="-25.00" default-x="117.71">
+        <pitch>
+          <step>A</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>eighth</type>
+        <time-modification>
+          <actual-notes>3</actual-notes>
+          <normal-notes>2</normal-notes>
+        </time-modification>
+        <stem>down</stem>
+        <beam number="1">begin</beam>
+        <notations>
+          <tuplet type="start" bracket="no" />
+        </notations>
+        <lyric number="1" name="verse1">
+          <syllabic>single</syllabic>
+          <text>All</text>
+        </lyric>
+      </note>
+      <note default-y="-20.00" default-x="171.89">
+        <pitch>
+          <step>B</step>
+          <alter>-1</alter>
+          <octave>4</octave>
+        </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>eighth</type>
+        <time-modification>
+          <actual-notes>3</actual-notes>
+          <normal-notes>2</normal-notes>
+        </time-modification>
+        <stem>down</stem>
+        <beam number="1">continue</beam>
+        <lyric number="1" name="verse1">
+          <syllabic>single</syllabic>
+          <text>in</text>
+        </lyric>
+      </note>
+      <note default-y="-15.00" default-x="226.07">
+        <pitch>
+          <step>C</step>
+          <octave>5</octave>
+        </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>eighth</type>
+        <time-modification>
+          <actual-notes>3</actual-notes>
+          <normal-notes>2</normal-notes>
+        </time-modification>
+        <stem>down</stem>
+        <beam number="1">end</beam>
+        <notations>
+          <tuplet type="stop" />
+        </notations>
+        <lyric number="1" name="verse1">
+          <syllabic>single</syllabic>
+          <text>the</text>
+        </lyric>
+      </note>
+      <harmony print-frame="no">
+        <root>
+          <root-step>B</root-step>
+          <root-alter>-1</root-alter>
+        </root>
+        <kind text="Maj7">major-seventh</kind>
+      </harmony>
+      <note default-y="-10.00" default-x="280.25">
+        <pitch>
+          <step>D</step>
+          <octave>5</octave>
+        </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>eighth</type>
+        <time-modification>
+          <actual-notes>3</actual-notes>
+          <normal-notes>2</normal-notes>
+        </time-modification>
+        <stem>down</stem>
+        <beam number="1">begin</beam>
+        <notations>
+          <tuplet type="start" bracket="no" />
+        </notations>
+        <lyric number="1" name="verse1">
+          <syllabic>begin</syllabic>
+          <text>won</text>
+        </lyric>
+      </note>
+      <note default-y="-15.00" default-x="334.43">
+        <pitch>
+          <step>C</step>
+          <octave>5</octave>
+        </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>eighth</type>
+        <time-modification>
+          <actual-notes>3</actual-notes>
+          <normal-notes>2</normal-notes>
+        </time-modification>
+        <stem>down</stem>
+        <beam number="1">continue</beam>
+        <lyric number="1" name="verse1">
+          <syllabic>middle</syllabic>
+          <text>der</text>
+        </lyric>
+      </note>
+      <note default-y="-20.00" default-x="388.62">
+        <pitch>
+          <step>B</step>
+          <alter>-1</alter>
+          <octave>4</octave>
+        </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>eighth</type>
+        <time-modification>
+          <actual-notes>3</actual-notes>
+          <normal-notes>2</normal-notes>
+        </time-modification>
+        <stem>down</stem>
+        <beam number="1">end</beam>
+        <notations>
+          <tuplet type="stop" />
+        </notations>
+        <lyric number="1" name="verse1">
+          <syllabic>end</syllabic>
+          <text>ful</text>
+        </lyric>
+      </note>
+    </measure>
+    <measure width="336.45" number="6">
+      <harmony print-frame="no">
+        <root>
+          <root-step>F</root-step>
+        </root>
+        <kind text="">major</kind>
+      </harmony>
+      <note default-y="-25.00" default-x="29.04">
+        <pitch>
+          <step>A</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>12</duration>
+        <voice>1</voice>
+        <type>half</type>
+        <stem>up</stem>
+        <lyric number="1" name="verse1">
+          <syllabic>single</syllabic>
+          <text>game</text>
+        </lyric>
+      </note>
+      <note default-y="-15.00" default-x="189.23">
+        <pitch>
+          <step>C</step>
+          <octave>5</octave>
+        </pitch>
+        <duration>3</duration>
+        <voice>1</voice>
+        <type>eighth</type>
+        <stem>up</stem>
+        <beam number="1">begin</beam>
+        <lyric number="1" name="verse1">
+          <syllabic>single</syllabic>
+          <text>that</text>
+        </lyric>
+      </note>
+      <note default-y="-25.00" default-x="262.04">
+        <pitch>
+          <step>A</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>3</duration>
+        <voice>1</voice>
+        <type>eighth</type>
+        <stem>up</stem>
+        <beam number="1">end</beam>
+        <lyric number="1" name="verse1">
+          <syllabic>single</syllabic>
+          <text>we</text>
+        </lyric>
+      </note>
+    </measure>
+    <measure width="291.90" number="7">
+      <harmony print-frame="no">
+        <root>
+          <root-step>B</root-step>
+          <root-alter>-1</root-alter>
+        </root>
+        <kind text="">major</kind>
+      </harmony>
+      <note default-y="-10.00" default-x="29.67">
+        <pitch>
+          <step>D</step>
+          <octave>5</octave>
+        </pitch>
+        <duration>12</duration>
+        <voice>1</voice>
+        <type>half</type>
+        <stem>down</stem>
+        <lyric number="1" name="verse1">
+          <syllabic>single</syllabic>
+          <text>know</text>
+        </lyric>
+      </note>
+      <note default-y="-35.00" default-x="190.06">
+        <pitch>
+          <step>F</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>6</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        <lyric number="1" name="verse1">
+          <syllabic>single</syllabic>
+          <text>as</text>
+        </lyric>
+      </note>
+    </measure>
+    <measure width="257.59" number="8">
+      <harmony print-frame="no">
+        <root>
+          <root-step>F</root-step>
+        </root>
+        <kind text="">major</kind>
+      </harmony>
+      <note default-y="-25.00" default-x="26.88">
+        <pitch>
+          <step>A</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>18</duration>
+        <tie type="start" />
+        <voice>1</voice>
+        <type>half</type>
+        <dot />
+        <stem>up</stem>
+        <notations>
+          <tied type="start" />
+        </notations>
+        <lyric number="1" name="verse1">
+          <syllabic>single</syllabic>
+          <text>love.</text>
+        </lyric>
+      </note>
+    </measure>
+    <measure width="329.02" number="9">
+      <print new-system="yes">
+        <system-layout>
+          <system-margins>
+            <left-margin>3.00</left-margin>
+            <right-margin>0.00</right-margin>
+          </system-margins>
+          <system-distance>166.96</system-distance>
+        </system-layout>
+      </print>
+      <note default-y="-25.00" default-x="12.00">
+        <pitch>
+          <step>A</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>6</duration>
+        <tie type="stop" />
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        <notations>
+          <tied type="stop" />
+        </notations>
+      </note>
+      <note>
+        <rest />
+        <duration>6</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+      </note>
+      <note default-y="-25.00" default-x="206.10">
+        <pitch>
+          <step>A</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>3</duration>
+        <voice>1</voice>
+        <type>eighth</type>
+        <stem>up</stem>
+        <beam number="1">begin</beam>
+        <lyric number="1" name="verse1">
+          <syllabic>single</syllabic>
+          <text>You</text>
+        </lyric>
+      </note>
+      <note default-y="-20.00" default-x="266.76">
+        <pitch>
+          <step>B</step>
+          <alter>-1</alter>
+          <octave>4</octave>
+        </pitch>
+        <duration>3</duration>
+        <voice>1</voice>
+        <type>eighth</type>
+        <stem>up</stem>
+        <beam number="1">end</beam>
+        <lyric number="1" name="verse1">
+          <syllabic>single</syllabic>
+          <text>have</text>
+        </lyric>
+      </note>
+    </measure>
+    <measure width="301.46" number="10">
+      <note default-y="-15.00" default-x="32.16">
+        <pitch>
+          <step>C</step>
+          <octave>5</octave>
+        </pitch>
+        <duration>12</duration>
+        <voice>1</voice>
+        <type>half</type>
+        <stem>down</stem>
+        <lyric number="1" name="verse1">
+          <syllabic>single</syllabic>
+          <text>words</text>
+        </lyric>
+      </note>
+      <note default-y="-50.00" default-x="196.90">
+        <pitch>
+          <step>C</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>6</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        <lyric number="1" name="verse1">
+          <syllabic>single</syllabic>
+          <text>with</text>
+        </lyric>
+      </note>
+    </measure>
+    <measure width="322.61" number="11">
+      <harmony print-frame="no">
+        <root>
+          <root-step>D</root-step>
+        </root>
+        <kind text="m">minor</kind>
+      </harmony>
+      <note default-y="-45.00" default-x="22.23">
+        <pitch>
+          <step>D</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>12</duration>
+        <voice>1</voice>
+        <type>half</type>
+        <stem>up</stem>
+        <lyric number="1" name="verse1">
+          <syllabic>single</syllabic>
+          <text>him</text>
+        </lyric>
+      </note>
+      <note default-y="-25.00" default-x="178.73">
+        <pitch>
+          <step>A</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>3</duration>
+        <voice>1</voice>
+        <type>eighth</type>
+        <stem>up</stem>
+        <beam number="1">begin</beam>
+        <lyric number="1" name="verse1">
+          <syllabic>single</syllabic>
+          <text>and</text>
+        </lyric>
+      </note>
+      <note default-y="-20.00" default-x="249.87">
+        <pitch>
+          <step>B</step>
+          <alter>-1</alter>
+          <octave>4</octave>
+        </pitch>
+        <duration>3</duration>
+        <voice>1</voice>
+        <type>eighth</type>
+        <stem>up</stem>
+        <beam number="1">end</beam>
+        <lyric number="1" name="verse1">
+          <syllabic>single</syllabic>
+          <text>your</text>
+        </lyric>
+      </note>
+    </measure>
+    <measure width="377.24" number="12">
+      <harmony print-frame="no">
+        <root>
+          <root-step>F</root-step>
+        </root>
+        <kind text="">major</kind>
+      </harmony>
+      <note default-y="-15.00" default-x="14.15">
+        <pitch>
+          <step>C</step>
+          <octave>5</octave>
+        </pitch>
+        <duration>6</duration>
+        <tie type="start" />
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        <notations>
+          <tied type="start" />
+        </notations>
+        <lyric number="1" name="verse1">
+          <syllabic>begin</syllabic>
+          <text>fu</text>
+        </lyric>
+      </note>
+      <note default-y="-15.00" default-x="117.43">
+        <pitch>
+          <step>C</step>
+          <octave>5</octave>
+        </pitch>
+        <duration>3</duration>
+        <tie type="stop" />
+        <voice>1</voice>
+        <type>eighth</type>
+        <stem>down</stem>
+        <beam number="1">begin</beam>
+        <notations>
+          <tied type="stop" />
+        </notations>
+      </note>
+      <note default-y="-10.00" default-x="181.99">
+        <pitch>
+          <step>D</step>
+          <octave>5</octave>
+        </pitch>
+        <duration>3</duration>
+        <voice>1</voice>
+        <type>eighth</type>
+        <stem>down</stem>
+        <beam number="1">end</beam>
+        <lyric number="1" name="verse1">
+          <syllabic>end</syllabic>
+          <text>ture's</text>
+        </lyric>
+      </note>
+      <harmony print-frame="no">
+        <root>
+          <root-step>G</root-step>
+        </root>
+        <kind text="">major</kind>
+      </harmony>
+      <note default-y="-20.00" default-x="246.54">
+        <pitch>
+          <step>B</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>3</duration>
+        <voice>1</voice>
+        <type>eighth</type>
+        <accidental>natural</accidental>
+        <stem>up</stem>
+        <beam number="1">begin</beam>
+        <lyric number="1" name="verse1">
+          <syllabic>begin</syllabic>
+          <text>look</text>
+        </lyric>
+      </note>
+      <note default-y="-30.00" default-x="311.09">
+        <pitch>
+          <step>G</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>3</duration>
+        <voice>1</voice>
+        <type>eighth</type>
+        <stem>up</stem>
+        <beam number="1">end</beam>
+        <lyric number="1" name="verse1">
+          <syllabic>end</syllabic>
+          <text>ing</text>
+        </lyric>
+      </note>
+    </measure>
+    <measure width="349.76" number="13">
+      <print new-system="yes">
+        <system-layout>
+          <system-margins>
+            <left-margin>3.00</left-margin>
+            <right-margin>0.00</right-margin>
+          </system-margins>
+          <system-distance>166.96</system-distance>
+        </system-layout>
+      </print>
+      <harmony print-frame="no">
+        <root>
+          <root-step>C</root-step>
+        </root>
+        <kind text="">major</kind>
+      </harmony>
+      <note default-y="-5.00" default-x="25.02">
+        <pitch>
+          <step>E</step>
+          <octave>5</octave>
+        </pitch>
+        <duration>12</duration>
+        <voice>1</voice>
+        <type>half</type>
+        <stem>down</stem>
+        <lyric number="1" name="verse1">
+          <syllabic>single</syllabic>
+          <text>dim,</text>
+        </lyric>
+      </note>
+      <note default-y="-5.00" default-x="194.29">
+        <pitch>
+          <step>E</step>
+          <octave>5</octave>
+        </pitch>
+        <duration>3</duration>
+        <voice>1</voice>
+        <type>eighth</type>
+        <stem>down</stem>
+        <beam number="1">begin</beam>
+        <lyric number="1" name="verse1">
+          <syllabic>single</syllabic>
+          <text>but</text>
+        </lyric>
+      </note>
+      <note default-y="-15.00" default-x="271.22">
+        <pitch>
+          <step>C</step>
+          <octave>5</octave>
+        </pitch>
+        <duration>3</duration>
+        <voice>1</voice>
+        <type>eighth</type>
+        <stem>down</stem>
+        <beam number="1">end</beam>
+        <lyric number="1" name="verse1">
+          <syllabic>single</syllabic>
+          <text>these</text>
+        </lyric>
+      </note>
+    </measure>
+    <measure width="440.58" number="14">
+      <note default-y="-30.00" default-x="32.17">
+        <pitch>
+          <step>G</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>6</duration>
+        <tie type="start" />
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        <notations>
+          <tied type="start" />
+        </notations>
+        <lyric number="1" name="verse1">
+          <syllabic>single</syllabic>
+          <text>things</text>
+        </lyric>
+      </note>
+      <note default-y="-30.00" default-x="148.40">
+        <pitch>
+          <step>G</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>3</duration>
+        <tie type="stop" />
+        <voice>1</voice>
+        <type>eighth</type>
+        <stem>up</stem>
+        <beam number="1">begin</beam>
+        <notations>
+          <tied type="stop" />
+        </notations>
+      </note>
+      <note default-y="-25.00" default-x="221.04">
+        <pitch>
+          <step>A</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>3</duration>
+        <voice>1</voice>
+        <type>eighth</type>
+        <stem>up</stem>
+        <beam number="1">end</beam>
+        <lyric number="1" name="verse1">
+          <syllabic>single</syllabic>
+          <text>your</text>
+        </lyric>
+      </note>
+      <harmony print-frame="no">
+        <root>
+          <root-step>G</root-step>
+        </root>
+        <kind text="dim">diminished</kind>
+      </harmony>
+      <note default-y="-35.00" default-x="293.69">
+        <pitch>
+          <step>F</step>
+          <alter>1</alter>
+          <octave>4</octave>
+        </pitch>
+        <duration>3</duration>
+        <voice>1</voice>
+        <type>eighth</type>
+        <accidental>sharp</accidental>
+        <stem>up</stem>
+        <beam number="1">begin</beam>
+        <lyric number="1" name="verse1">
+          <syllabic>single</syllabic>
+          <text>hearts</text>
+        </lyric>
+      </note>
+      <note default-y="-30.00" default-x="366.33">
+        <pitch>
+          <step>G</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>3</duration>
+        <voice>1</voice>
+        <type>eighth</type>
+        <stem>up</stem>
+        <beam number="1">end</beam>
+        <lyric number="1" name="verse1">
+          <syllabic>single</syllabic>
+          <text>can</text>
+        </lyric>
+      </note>
+    </measure>
+    <measure width="276.59" number="15">
+      <harmony print-frame="no">
+        <root>
+          <root-step>G</root-step>
+        </root>
+        <kind text="9">dominant-ninth</kind>
+      </harmony>
+      <note default-y="-10.00" default-x="20.98">
+        <pitch>
+          <step>D</step>
+          <octave>5</octave>
+        </pitch>
+        <duration>12</duration>
+        <voice>1</voice>
+        <type>half</type>
+        <stem>down</stem>
+        <lyric number="1" name="verse1">
+          <syllabic>single</syllabic>
+          <text>rise</text>
+        </lyric>
+      </note>
+      <harmony print-frame="no">
+        <root>
+          <root-step>G</root-step>
+        </root>
+        <kind text="7">dominant</kind>
+      </harmony>
+      <note default-y="-5.00" default-x="177.29">
+        <pitch>
+          <step>E</step>
+          <octave>5</octave>
+        </pitch>
+        <duration>6</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        <lyric number="1" name="verse1">
+          <syllabic>begin</syllabic>
+          <text>a</text>
+        </lyric>
+      </note>
+    </measure>
+    <measure width="263.41" number="16">
+      <harmony print-frame="no">
+        <root>
+          <root-step>C</root-step>
+        </root>
+        <kind text="7">dominant</kind>
+      </harmony>
+      <note default-y="-15.00" default-x="26.57">
+        <pitch>
+          <step>C</step>
+          <octave>5</octave>
+        </pitch>
+        <duration>18</duration>
+        <voice>1</voice>
+        <type>half</type>
+        <dot />
+        <stem>down</stem>
+        <lyric number="1" name="verse1">
+          <syllabic>end</syllabic>
+          <text>bove</text>
+        </lyric>
+      </note>
+    </measure>
+    <measure width="474.60" number="17">
+      <print new-system="yes">
+        <system-layout>
+          <system-margins>
+            <left-margin>3.00</left-margin>
+            <right-margin>0.00</right-margin>
+          </system-margins>
+          <system-distance>166.96</system-distance>
+        </system-layout>
+      </print>
+      <note>
+        <rest />
+        <duration>6</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+      </note>
+      <harmony print-frame="no">
+        <root>
+          <root-step>F</root-step>
+        </root>
+        <kind text="">major</kind>
+      </harmony>
+      <note default-y="-25.00" default-x="125.12">
+        <pitch>
+          <step>A</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>eighth</type>
+        <time-modification>
+          <actual-notes>3</actual-notes>
+          <normal-notes>2</normal-notes>
+        </time-modification>
+        <stem>down</stem>
+        <beam number="1">begin</beam>
+        <notations>
+          <tuplet type="start" bracket="no" />
+        </notations>
+        <lyric number="1" name="verse1">
+          <syllabic>single</syllabic>
+          <text>Once</text>
+        </lyric>
+      </note>
+      <note default-y="-20.00" default-x="183.10">
+        <pitch>
+          <step>B</step>
+          <alter>-1</alter>
+          <octave>4</octave>
+        </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>eighth</type>
+        <time-modification>
+          <actual-notes>3</actual-notes>
+          <normal-notes>2</normal-notes>
+        </time-modification>
+        <stem>down</stem>
+        <beam number="1">continue</beam>
+        <lyric number="1" name="verse1">
+          <syllabic>single</syllabic>
+          <text>in</text>
+        </lyric>
+      </note>
+      <note default-y="-15.00" default-x="241.08">
+        <pitch>
+          <step>C</step>
+          <octave>5</octave>
+        </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>eighth</type>
+        <time-modification>
+          <actual-notes>3</actual-notes>
+          <normal-notes>2</normal-notes>
+        </time-modification>
+        <stem>down</stem>
+        <beam number="1">end</beam>
+        <notations>
+          <tuplet type="stop" />
+        </notations>
+        <lyric number="1" name="verse1">
+          <syllabic>single</syllabic>
+          <text>a</text>
+        </lyric>
+      </note>
+      <harmony print-frame="no">
+        <root>
+          <root-step>B</root-step>
+          <root-alter>-1</root-alter>
+        </root>
+        <kind text="Maj7">major-seventh</kind>
+      </harmony>
+      <note default-y="-10.00" default-x="299.06">
+        <pitch>
+          <step>D</step>
+          <octave>5</octave>
+        </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>eighth</type>
+        <time-modification>
+          <actual-notes>3</actual-notes>
+          <normal-notes>2</normal-notes>
+        </time-modification>
+        <stem>down</stem>
+        <beam number="1">begin</beam>
+        <notations>
+          <tuplet type="start" bracket="no" />
+        </notations>
+        <lyric number="1" name="verse1">
+          <syllabic>single</syllabic>
+          <text>while</text>
+        </lyric>
+      </note>
+      <note default-y="-15.00" default-x="357.04">
+        <pitch>
+          <step>C</step>
+          <octave>5</octave>
+        </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>eighth</type>
+        <time-modification>
+          <actual-notes>3</actual-notes>
+          <normal-notes>2</normal-notes>
+        </time-modification>
+        <stem>down</stem>
+        <beam number="1">continue</beam>
+        <lyric number="1" name="verse1">
+          <syllabic>single</syllabic>
+          <text>he</text>
+        </lyric>
+      </note>
+      <note default-y="-20.00" default-x="415.02">
+        <pitch>
+          <step>B</step>
+          <alter>-1</alter>
+          <octave>4</octave>
+        </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>eighth</type>
+        <time-modification>
+          <actual-notes>3</actual-notes>
+          <normal-notes>2</normal-notes>
+        </time-modification>
+        <stem>down</stem>
+        <beam number="1">end</beam>
+        <notations>
+          <tuplet type="stop" />
+        </notations>
+        <lyric number="1" name="verse1">
+          <syllabic>single</syllabic>
+          <text>won't</text>
+        </lyric>
+      </note>
+    </measure>
+    <measure width="307.49" number="18">
+      <harmony print-frame="no">
+        <root>
+          <root-step>F</root-step>
+        </root>
+        <kind text="Maj7">major-seventh</kind>
+      </harmony>
+      <note default-y="-25.00" default-x="20.97">
+        <pitch>
+          <step>A</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>12</duration>
+        <voice>1</voice>
+        <type>half</type>
+        <stem>up</stem>
+        <lyric number="1" name="verse1">
+          <syllabic>single</syllabic>
+          <text>call</text>
+        </lyric>
+      </note>
+      <note default-y="-30.00" default-x="170.21">
+        <pitch>
+          <step>G</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>3</duration>
+        <voice>1</voice>
+        <type>eighth</type>
+        <stem>up</stem>
+        <beam number="1">begin</beam>
+        <lyric number="1" name="verse1">
+          <syllabic>single</syllabic>
+          <text>but</text>
+        </lyric>
+      </note>
+      <note default-y="-40.00" default-x="238.05">
+        <pitch>
+          <step>E</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>3</duration>
+        <voice>1</voice>
+        <type>eighth</type>
+        <stem>up</stem>
+        <beam number="1">end</beam>
+        <lyric number="1" name="verse1">
+          <syllabic>single</syllabic>
+          <text>it's</text>
+        </lyric>
+      </note>
+    </measure>
+    <measure width="293.27" number="19">
+      <harmony print-frame="no">
+        <root>
+          <root-step>B</root-step>
+          <root-alter>-1</root-alter>
+        </root>
+        <kind text="">major</kind>
+      </harmony>
+      <note default-y="-45.00" default-x="16.01">
+        <pitch>
+          <step>D</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>12</duration>
+        <voice>1</voice>
+        <type>half</type>
+        <stem>up</stem>
+        <lyric number="1" name="verse1">
+          <syllabic>single</syllabic>
+          <text>all</text>
+        </lyric>
+      </note>
+      <harmony print-frame="no">
+        <root>
+          <root-step>C</root-step>
+        </root>
+        <kind text="7">dominant</kind>
+      </harmony>
+      <note default-y="-30.00" default-x="160.40">
+        <pitch>
+          <step>G</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>3</duration>
+        <voice>1</voice>
+        <type>eighth</type>
+        <stem>up</stem>
+        <beam number="1">begin</beam>
+        <lyric number="1" name="verse1">
+          <syllabic>single</syllabic>
+          <text>in</text>
+        </lyric>
+      </note>
+      <note default-y="-40.00" default-x="226.04">
+        <pitch>
+          <step>E</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>3</duration>
+        <voice>1</voice>
+        <type>eighth</type>
+        <stem>up</stem>
+        <beam number="1">end</beam>
+        <lyric number="1" name="verse1">
+          <syllabic>single</syllabic>
+          <text>the</text>
+        </lyric>
+      </note>
+    </measure>
+    <measure width="254.97" number="20">
+      <harmony print-frame="no">
+        <root>
+          <root-step>F</root-step>
+        </root>
+        <kind text="">major</kind>
+      </harmony>
+      <note default-y="-50.00" default-x="29.04">
+        <pitch>
+          <step>C</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>18</duration>
+        <voice>1</voice>
+        <type>half</type>
+        <dot />
+        <stem>up</stem>
+        <lyric number="1" name="verse1">
+          <syllabic>single</syllabic>
+          <text>game</text>
+        </lyric>
+      </note>
+    </measure>
+    <measure width="414.54" number="21">
+      <print new-system="yes">
+        <system-layout>
+          <system-margins>
+            <left-margin>3.00</left-margin>
+            <right-margin>0.00</right-margin>
+          </system-margins>
+          <system-distance>166.96</system-distance>
+        </system-layout>
+      </print>
+      <note>
+        <rest />
+        <duration>6</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+      </note>
+      <note default-y="-25.00" default-x="110.38">
+        <pitch>
+          <step>A</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>eighth</type>
+        <time-modification>
+          <actual-notes>3</actual-notes>
+          <normal-notes>2</normal-notes>
+        </time-modification>
+        <stem>down</stem>
+        <beam number="1">begin</beam>
+        <notations>
+          <tuplet type="start" bracket="no" />
+        </notations>
+        <lyric number="1" name="verse1">
+          <syllabic>single</syllabic>
+          <text>Soon</text>
+        </lyric>
+      </note>
+      <note default-y="-20.00" default-x="160.81">
+        <pitch>
+          <step>B</step>
+          <alter>-1</alter>
+          <octave>4</octave>
+        </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>eighth</type>
+        <time-modification>
+          <actual-notes>3</actual-notes>
+          <normal-notes>2</normal-notes>
+        </time-modification>
+        <stem>down</stem>
+        <beam number="1">continue</beam>
+        <lyric number="1" name="verse1">
+          <syllabic>single</syllabic>
+          <text>he'll</text>
+        </lyric>
+      </note>
+      <note default-y="-15.00" default-x="211.23">
+        <pitch>
+          <step>C</step>
+          <octave>5</octave>
+        </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>eighth</type>
+        <time-modification>
+          <actual-notes>3</actual-notes>
+          <normal-notes>2</normal-notes>
+        </time-modification>
+        <stem>down</stem>
+        <beam number="1">end</beam>
+        <notations>
+          <tuplet type="stop" />
+        </notations>
+        <lyric number="1" name="verse1">
+          <syllabic>single</syllabic>
+          <text>be</text>
+        </lyric>
+      </note>
+      <harmony print-frame="no">
+        <root>
+          <root-step>B</root-step>
+          <root-alter>-1</root-alter>
+        </root>
+        <kind text="Maj7">major-seventh</kind>
+      </harmony>
+      <note default-y="-10.00" default-x="261.66">
+        <pitch>
+          <step>D</step>
+          <octave>5</octave>
+        </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>eighth</type>
+        <time-modification>
+          <actual-notes>3</actual-notes>
+          <normal-notes>2</normal-notes>
+        </time-modification>
+        <stem>down</stem>
+        <beam number="1">begin</beam>
+        <notations>
+          <tuplet type="start" bracket="no" />
+        </notations>
+        <lyric number="1" name="verse1">
+          <syllabic>single</syllabic>
+          <text>there</text>
+        </lyric>
+      </note>
+      <note default-y="-15.00" default-x="312.08">
+        <pitch>
+          <step>C</step>
+          <octave>5</octave>
+        </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>eighth</type>
+        <time-modification>
+          <actual-notes>3</actual-notes>
+          <normal-notes>2</normal-notes>
+        </time-modification>
+        <stem>down</stem>
+        <beam number="1">continue</beam>
+        <lyric number="1" name="verse1">
+          <syllabic>single</syllabic>
+          <text>at</text>
+        </lyric>
+      </note>
+      <note default-y="-20.00" default-x="362.51">
+        <pitch>
+          <step>B</step>
+          <alter>-1</alter>
+          <octave>4</octave>
+        </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>eighth</type>
+        <time-modification>
+          <actual-notes>3</actual-notes>
+          <normal-notes>2</normal-notes>
+        </time-modification>
+        <stem>down</stem>
+        <beam number="1">end</beam>
+        <notations>
+          <tuplet type="stop" />
+        </notations>
+        <lyric number="1" name="verse1">
+          <syllabic>single</syllabic>
+          <text>your</text>
+        </lyric>
+      </note>
+    </measure>
+    <measure width="247.94" number="22">
+      <harmony print-frame="no">
+        <root>
+          <root-step>F</root-step>
+        </root>
+        <kind text="Maj7">major-seventh</kind>
+      </harmony>
+      <note default-y="-25.00" default-x="22.84">
+        <pitch>
+          <step>A</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>12</duration>
+        <voice>1</voice>
+        <type>half</type>
+        <stem>up</stem>
+        <lyric number="1" name="verse1">
+          <syllabic>single</syllabic>
+          <text>side</text>
+        </lyric>
+      </note>
+      <note default-y="-15.00" default-x="139.91">
+        <pitch>
+          <step>C</step>
+          <octave>5</octave>
+        </pitch>
+        <duration>3</duration>
+        <voice>1</voice>
+        <type>eighth</type>
+        <stem>up</stem>
+        <beam number="1">begin</beam>
+        <lyric number="1" name="verse1">
+          <syllabic>single</syllabic>
+          <text>with</text>
+        </lyric>
+      </note>
+      <note default-y="-25.00" default-x="193.12">
+        <pitch>
+          <step>A</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>3</duration>
+        <voice>1</voice>
+        <type>eighth</type>
+        <stem>up</stem>
+        <beam number="1">end</beam>
+        <lyric number="1" name="verse1">
+          <syllabic>single</syllabic>
+          <text>a</text>
+        </lyric>
+      </note>
+    </measure>
+    <measure width="232.26" number="23">
+      <harmony print-frame="no">
+        <root>
+          <root-step>B</root-step>
+          <root-alter>-1</root-alter>
+        </root>
+        <kind text="">major</kind>
+      </harmony>
+      <note default-y="-10.00" default-x="30.28">
+        <pitch>
+          <step>D</step>
+          <octave>5</octave>
+        </pitch>
+        <duration>12</duration>
+        <voice>1</voice>
+        <type>half</type>
+        <stem>down</stem>
+        <lyric number="1" name="verse1">
+          <syllabic>single</syllabic>
+          <text>sweet</text>
+        </lyric>
+      </note>
+      <note default-y="-35.00" default-x="153.59">
+        <pitch>
+          <step>F</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>6</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        <lyric number="1" name="verse1">
+          <syllabic>begin</syllabic>
+          <text>bou</text>
+        </lyric>
+      </note>
+    </measure>
+    <measure width="184.44" number="24">
+      <harmony print-frame="no">
+        <root>
+          <root-step>F</root-step>
+        </root>
+        <kind text="">major</kind>
+      </harmony>
+      <note default-y="-25.00" default-x="26.88">
+        <pitch>
+          <step>A</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>18</duration>
+        <tie type="start" />
+        <voice>1</voice>
+        <type>half</type>
+        <dot />
+        <stem>up</stem>
+        <notations>
+          <tied type="start" />
+        </notations>
+        <lyric number="1" name="verse1">
+          <syllabic>end</syllabic>
+          <text>quet,</text>
+        </lyric>
+      </note>
+    </measure>
+    <measure width="251.16" number="25">
+      <note default-y="-25.00" default-x="12.00">
+        <pitch>
+          <step>A</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>12</duration>
+        <tie type="stop" />
+        <voice>1</voice>
+        <type>half</type>
+        <stem>up</stem>
+        <notations>
+          <tied type="stop" />
+        </notations>
+      </note>
+      <note default-y="-25.00" default-x="136.44">
+        <pitch>
+          <step>A</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>3</duration>
+        <voice>1</voice>
+        <type>eighth</type>
+        <stem>up</stem>
+        <beam number="1">begin</beam>
+        <lyric number="1" name="verse1">
+          <syllabic>single</syllabic>
+          <text>And</text>
+        </lyric>
+      </note>
+      <note default-y="-20.00" default-x="193.00">
+        <pitch>
+          <step>B</step>
+          <alter>-1</alter>
+          <octave>4</octave>
+        </pitch>
+        <duration>3</duration>
+        <voice>1</voice>
+        <type>eighth</type>
+        <stem>up</stem>
+        <beam number="1">end</beam>
+        <lyric number="1" name="verse1">
+          <syllabic>single</syllabic>
+          <text>he'll</text>
+        </lyric>
+      </note>
+    </measure>
+    <measure width="216.00" number="26">
+      <print new-system="yes">
+        <system-layout>
+          <system-margins>
+            <left-margin>3.00</left-margin>
+            <right-margin>-0.00</right-margin>
+          </system-margins>
+          <system-distance>166.96</system-distance>
+        </system-layout>
+      </print>
+      <note default-y="-15.00" default-x="22.23">
+        <pitch>
+          <step>C</step>
+          <octave>5</octave>
+        </pitch>
+        <duration>12</duration>
+        <voice>1</voice>
+        <type>half</type>
+        <stem>down</stem>
+        <lyric number="1" name="verse1">
+          <syllabic>single</syllabic>
+          <text>kiss</text>
+        </lyric>
+      </note>
+      <harmony print-frame="no">
+        <root>
+          <root-step>A</root-step>
+        </root>
+        <kind text="m">minor</kind>
+      </harmony>
+      <note default-y="-50.00" default-x="140.49">
+        <pitch>
+          <step>C</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>6</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        <lyric number="1" name="verse1">
+          <syllabic>single</syllabic>
+          <text>tour</text>
+        </lyric>
+      </note>
+    </measure>
+    <measure width="239.09" number="27">
+      <harmony print-frame="no">
+        <root>
+          <root-step>D</root-step>
+        </root>
+        <kind text="m">minor</kind>
+      </harmony>
+      <note default-y="-45.00" default-x="20.99">
+        <pitch>
+          <step>D</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>12</duration>
+        <voice>1</voice>
+        <type>half</type>
+        <stem>up</stem>
+        <lyric number="1" name="verse1">
+          <syllabic>single</syllabic>
+          <text>lips</text>
+        </lyric>
+      </note>
+      <note default-y="-25.00" default-x="134.39">
+        <pitch>
+          <step>A</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>3</duration>
+        <voice>1</voice>
+        <type>eighth</type>
+        <stem>up</stem>
+        <beam number="1">begin</beam>
+        <lyric number="1" name="verse1">
+          <syllabic>single</syllabic>
+          <text>and</text>
+        </lyric>
+      </note>
+      <note default-y="-15.00" default-x="185.94">
+        <pitch>
+          <step>C</step>
+          <octave>5</octave>
+        </pitch>
+        <duration>3</duration>
+        <voice>1</voice>
+        <type>eighth</type>
+        <stem>up</stem>
+        <beam number="1">end</beam>
+        <lyric number="1" name="verse1">
+          <syllabic>begin</syllabic>
+          <text>ca</text>
+        </lyric>
+      </note>
+    </measure>
+    <measure width="371.27" number="28">
+      <harmony print-frame="no">
+        <root>
+          <root-step>G</root-step>
+        </root>
+        <kind text="9">dominant-ninth</kind>
+      </harmony>
+      <note default-y="-5.00" default-x="22.23">
+        <pitch>
+          <step>E</step>
+          <octave>5</octave>
+        </pitch>
+        <duration>3</duration>
+        <voice>1</voice>
+        <type>eighth</type>
+        <stem>down</stem>
+        <beam number="1">begin</beam>
+        <lyric number="1" name="verse1">
+          <syllabic>end</syllabic>
+          <text>ress</text>
+        </lyric>
+      </note>
+      <note default-y="-10.00" default-x="80.13">
+        <pitch>
+          <step>D</step>
+          <octave>5</octave>
+        </pitch>
+        <duration>3</duration>
+        <voice>1</voice>
+        <type>eighth</type>
+        <stem>down</stem>
+        <beam number="1">end</beam>
+        <lyric number="1" name="verse1">
+          <syllabic>single</syllabic>
+          <text>your</text>
+        </lyric>
+      </note>
+      <note default-y="-15.00" default-x="138.04">
+        <pitch>
+          <step>C</step>
+          <octave>5</octave>
+        </pitch>
+        <duration>3</duration>
+        <voice>1</voice>
+        <type>eighth</type>
+        <stem>up</stem>
+        <beam number="1">begin</beam>
+        <lyric number="1" name="verse1">
+          <syllabic>begin</syllabic>
+          <text>wai</text>
+        </lyric>
+      </note>
+      <note default-y="-25.00" default-x="195.95">
+        <pitch>
+          <step>A</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>3</duration>
+        <voice>1</voice>
+        <type>eighth</type>
+        <stem>up</stem>
+        <beam number="1">end</beam>
+        <lyric number="1" name="verse1">
+          <syllabic>end</syllabic>
+          <text>ting</text>
+        </lyric>
+      </note>
+      <note default-y="-30.00" default-x="253.85">
+        <pitch>
+          <step>G</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>3</duration>
+        <voice>1</voice>
+        <type>eighth</type>
+        <stem>up</stem>
+        <beam number="1">begin</beam>
+        <lyric number="1" name="verse1">
+          <syllabic>begin</syllabic>
+          <text>fin</text>
+        </lyric>
+      </note>
+      <note default-y="-35.00" default-x="311.76">
+        <pitch>
+          <step>F</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>3</duration>
+        <voice>1</voice>
+        <type>eighth</type>
+        <stem>up</stem>
+        <beam number="1">end</beam>
+        <lyric number="1" name="verse1">
+          <syllabic>end</syllabic>
+          <text>ger</text>
+        </lyric>
+      </note>
+    </measure>
+    <measure width="270.65" number="29">
+      <harmony print-frame="no">
+        <root>
+          <root-step>G</root-step>
+        </root>
+        <kind text="7">dominant</kind>
+      </harmony>
+      <note default-y="-45.00" default-x="24.09">
+        <pitch>
+          <step>D</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>12</duration>
+        <voice>1</voice>
+        <type>half</type>
+        <stem>up</stem>
+        <lyric number="1" name="verse1">
+          <syllabic>single</syllabic>
+          <text>tips;</text>
+        </lyric>
+      </note>
+      <note default-y="-25.00" default-x="152.40">
+        <pitch>
+          <step>A</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>3</duration>
+        <voice>1</voice>
+        <type>eighth</type>
+        <stem>up</stem>
+        <beam number="1">begin</beam>
+        <lyric number="1" name="verse1">
+          <syllabic>single</syllabic>
+          <text>And</text>
+        </lyric>
+      </note>
+      <note default-y="-20.00" default-x="210.72">
+        <pitch>
+          <step>B</step>
+          <alter>-1</alter>
+          <octave>4</octave>
+        </pitch>
+        <duration>3</duration>
+        <voice>1</voice>
+        <type>eighth</type>
+        <stem>up</stem>
+        <beam number="1">end</beam>
+        <lyric number="1" name="verse1">
+          <syllabic>single</syllabic>
+          <text>your</text>
+        </lyric>
+      </note>
+    </measure>
+    <measure width="233.33" number="30">
+      <harmony print-frame="no">
+        <root>
+          <root-step>G</root-step>
+        </root>
+        <kind text="m7">minor-seventh</kind>
+      </harmony>
+      <note default-y="-15.00" default-x="31.53">
+        <pitch>
+          <step>C</step>
+          <octave>5</octave>
+        </pitch>
+        <duration>12</duration>
+        <voice>1</voice>
+        <type>half</type>
+        <stem>down</stem>
+        <lyric number="1" name="verse1">
+          <syllabic>single</syllabic>
+          <text>hearts</text>
+        </lyric>
+      </note>
+      <note default-y="-15.00" default-x="154.73">
+        <pitch>
+          <step>C</step>
+          <octave>5</octave>
+        </pitch>
+        <duration>6</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        <lyric number="1" name="verse1">
+          <syllabic>single</syllabic>
+          <text>will</text>
+        </lyric>
+      </note>
+    </measure>
+    <measure width="442.90" number="31">
+      <print new-system="yes">
+        <system-layout>
+          <system-margins>
+            <left-margin>3.00</left-margin>
+            <right-margin>0.00</right-margin>
+          </system-margins>
+          <system-distance>166.96</system-distance>
+        </system-layout>
+      </print>
+      <harmony print-frame="no">
+        <root>
+          <root-step>C</root-step>
+        </root>
+        <kind text="7">dominant</kind>
+      </harmony>
+      <note default-y="-10.00" default-x="17.25">
+        <pitch>
+          <step>D</step>
+          <octave>5</octave>
+        </pitch>
+        <duration>12</duration>
+        <voice>1</voice>
+        <type>half</type>
+        <stem>down</stem>
+        <lyric number="1" name="verse1">
+          <syllabic>single</syllabic>
+          <text>fly</text>
+        </lyric>
+      </note>
+      <note default-y="-15.00" default-x="278.21">
+        <pitch>
+          <step>C</step>
+          <octave>5</octave>
+        </pitch>
+        <duration>6</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        <lyric number="1" name="verse1">
+          <syllabic>begin</syllabic>
+          <text>a</text>
+        </lyric>
+      </note>
+    </measure>
+    <measure width="435.36" number="32">
+      <direction>
+        <direction-type>
+          <words default-y="100">F</words>
+        </direction-type>
+      </direction>
+      <note default-y="-35.00" default-x="25.57">
+        <pitch>
+          <step>F</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>18</duration>
+        <tie type="start" />
+        <voice>1</voice>
+        <type>half</type>
+        <dot />
+        <stem>up</stem>
+        <notations>
+          <tied type="start" />
+        </notations>
+        <lyric number="1" name="verse1">
+          <syllabic>end</syllabic>
+          <text>way.</text>
+        </lyric>
+      </note>
+    </measure>
+    <measure width="452.07" number="33">
+      <note default-y="-35.00" default-x="12.00">
+        <pitch>
+          <step>F</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>6</duration>
+        <tie type="stop" />
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        <notations>
+          <tied type="stop" />
+        </notations>
+      </note>
+      <note>
+        <rest />
+        <duration>6</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+      </note>
+      <note>
+        <rest />
+        <duration>6</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+      </note>
+      <barline location="right">
+        <bar-style>light-heavy</bar-style>
+      </barline>
+    </measure>
+  </part>
 </score-partwise>


### PR DESCRIPTION
* Add new elements `<print>`, `<lyric>`, `<print>`, `<tie>`, `<barline>`, ...
* Add type-safe versions of ChordSymbol's `root`, `kind`, `degreesTypeSafe`, `bass`

@de-men Hints:
* `Use enums` to parse attributes with a limited set of options into a type-safe version
* `ChordSymbol`: Instead of summarizing details, parse it in readable structures and provide a `toString()` method that provides a summarized string. 