### PR TITLE
Fix: Xml documents with multiple score parts were not read anymore

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,7 +36,7 @@ jobs:
         run: flutter pub get
 
       - name: Check format
-        run: flutter format --set-exit-if-changed .
+        run: dart format --set-exit-if-changed .
 
       - name: Analyze
         run: flutter analyze

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.2.2
+
+* fix: Xml documents with multiple score parts were not read anymore [#13](https://github.com/de-men/music_xml/pull/13)
+
 ## 1.2.1
 
 * fix: doubled ties [#9](https://github.com/de-men/music_xml/pull/9)

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ and the Flutter guide for
 # music_xml
 
 ![Build](https://github.com/de-men/music_xml/workflows/ci/badge.svg)
-[![pub package](https://img.shields.io/pub/v/music_xml.svg)](https://pub.dev/packages/draft_widget)
+[![pub package](https://img.shields.io/pub/v/music_xml.svg)](https://pub.dev/packages/music_xml)
 
 Simple MusicXML parser used to convert MusicXML into NoteSequence.
 

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -5,10 +5,10 @@ packages:
     dependency: transitive
     description:
       name: async
-      sha256: bfe67ef28df125b7dddcea62755991f807aa39a2492a23e1550161692950bbe0
+      sha256: "947bfcf187f74dbc5e146c9eb9c0f10c9f8b30743e341481c1e2ed3ecc18c20c"
       url: "https://pub.dev"
     source: hosted
-    version: "2.10.0"
+    version: "2.11.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -21,10 +21,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: e6a326c8af69605aec75ed6c187d06b349707a27fbff8222ca9cc2cff167975c
+      sha256: "04a925763edad70e8443c99234dc3328f442e811f1d8fd1a72f1c8ad0f69a605"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.1"
+    version: "1.3.0"
   clock:
     dependency: transitive
     description:
@@ -37,10 +37,10 @@ packages:
     dependency: transitive
     description:
       name: collection
-      sha256: cfc915e6923fe5ce6e153b0723c753045de46de1b4d63771530504004a45fae0
+      sha256: "4a07be6cb69c84d677a6c3096fcf960cc3285a8330b4603e0d463d15d9bd934c"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.17.1"
   cupertino_icons:
     dependency: "direct main"
     description:
@@ -79,10 +79,10 @@ packages:
     dependency: transitive
     description:
       name: js
-      sha256: "5528c2f391ededb7775ec1daa69e65a2d61276f7552de2b5f7b8d34ee9fd4ab7"
+      sha256: f2c445dce49627136094980615a031419f7f3eb393237e4ecd97ac15dea343f3
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.5"
+    version: "0.6.7"
   lints:
     dependency: transitive
     description:
@@ -95,10 +95,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "16db949ceee371e9b99d22f88fa3a73c4e59fd0afed0bd25fc336eb76c198b72"
+      sha256: "6501fbd55da300384b768785b83e5ce66991266cec21af89ab9ae7f5ce1c4cbb"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.13"
+    version: "0.12.15"
   material_color_utilities:
     dependency: transitive
     description:
@@ -111,25 +111,25 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "6c268b42ed578a53088d834796959e4a1814b5e9e164f147f580a386e5decf42"
+      sha256: "3c74dbf8763d36539f114c799d8a2d87343b5067e9d796ca22b5eb8437090ee3"
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.0"
+    version: "1.9.1"
   music_xml:
     dependency: "direct main"
     description:
       path: ".."
       relative: true
     source: path
-    version: "1.2.0"
+    version: "1.2.2"
   path:
     dependency: transitive
     description:
       name: path
-      sha256: db9d4f58c908a4ba5953fcee2ae317c94889433e5024c27ce74a37f94267945b
+      sha256: "8829d8a55c13fc0e37127c29fedf290c102f4e40ae94ada574091fe0ff96c917"
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.2"
+    version: "1.8.3"
   petitparser:
     dependency: transitive
     description:
@@ -187,10 +187,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: ad540f65f92caa91bf21dfc8ffb8c589d6e4dc0c2267818b4cc2792857706206
+      sha256: eb6ac1540b26de412b3403a163d919ba86f6a973fe6cc50ae3541b80092fdcfb
       url: "https://pub.dev"
     source: hosted
-    version: "0.4.16"
+    version: "0.5.1"
   vector_math:
     dependency: transitive
     description:
@@ -208,4 +208,4 @@ packages:
     source: hosted
     version: "6.2.2"
 sdks:
-  dart: ">=2.18.0 <3.0.0"
+  dart: ">=3.0.0-0 <4.0.0"

--- a/lib/src/music_xml_document.dart
+++ b/lib/src/music_xml_document.dart
@@ -37,9 +37,11 @@ class MusicXmlDocument extends XmlDocument {
         .findAllElements('part-list')
         .map((element) => element.findAllElements('score-part'))
         .where((element) => element.isNotEmpty)
-        .map((e) => e.single)
-        .map((element) => ScorePart.parse(element))
-        .forEach((ScorePart element) => scoreParts[element.id] = element);
+        .forEach(
+          (e) => e
+              .map((element) => ScorePart.parse(element))
+              .forEach((ScorePart element) => scoreParts[element.id] = element),
+        );
 
     // Parse parts
     final state = MusicXMLParserState();

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -378,4 +378,4 @@ packages:
     source: hosted
     version: "3.1.1"
 sdks:
-  dart: ">=2.19.0 <3.0.0"
+  dart: ">=2.19.0 <4.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,10 +1,10 @@
 name: music_xml
 description: A Dart package project to parse MusicXML. Inspired from Google's magenta.
-version: 1.2.1
+version: 1.2.2
 homepage: https://github.com/de-men/music_xml
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
+  sdk: ">=2.12.0 <4.0.0"
 
 dependencies:
   xml: ^6.1.0

--- a/test/score_parts_test.dart
+++ b/test/score_parts_test.dart
@@ -9,11 +9,7 @@ final emptyScoreParts = File('test/assets/emptyScoreParts.xml');
 void main() {
   test('MultipleScoreParts', () {
     expect(() => MusicXmlDocument.parse(multipleScoreParts.readAsStringSync()),
-        throwsA(isA<StateError>()));
-    expect(
-        () => MusicXmlDocument.parse(multipleScoreParts.readAsStringSync()),
-        throwsA(predicate(
-            (e) => e.toString().contains('Bad state: Too many elements'))));
+        returnsNormally);
   });
   test('EmptyScoreParts', () {
     final document = MusicXmlDocument.parse(emptyScoreParts.readAsStringSync());


### PR DESCRIPTION
Hello :-) 

In the last update you introduced an exception when an xml document contains more then one score-part. This is problematic for my use case working with documents having multiple score parts. 

I removed that restriction.

Please let me know, if this conflicts with other requirements.

Best, 
   Gabriel