### PR TITLE
fix: add default case to KeyAccidental.parse

### DIFF
--- a/lib/src/element/part/measure/attributes/key/key_accidental.dart
+++ b/lib/src/element/part/measure/attributes/key/key_accidental.dart
@@ -176,6 +176,9 @@ class KeyAccidental extends XmlElement {
       case 'other':
         accidentalValue = AccidentalValue.other;
         break;
+      default:
+        accidentalValue = AccidentalValue.other;
+        break;
     }
 
     return KeyAccidental(accidentalValue);

--- a/test/key_accidental_test.dart
+++ b/test/key_accidental_test.dart
@@ -1,0 +1,30 @@
+import 'package:music_xml/src/element/part/measure/attributes/key/key_accidental.dart';
+import 'package:test/test.dart';
+import 'package:xml/xml.dart';
+
+void main() {
+  test('parses known accidental values', () {
+    final sharp = KeyAccidental.parse(
+      XmlDocument.parse('<key-accidental>sharp</key-accidental>').rootElement,
+    );
+    expect(sharp.accidentalValue, AccidentalValue.sharp);
+
+    final flat = KeyAccidental.parse(
+      XmlDocument.parse('<key-accidental>flat</key-accidental>').rootElement,
+    );
+    expect(flat.accidentalValue, AccidentalValue.flat);
+
+    final natural = KeyAccidental.parse(
+      XmlDocument.parse('<key-accidental>natural</key-accidental>').rootElement,
+    );
+    expect(natural.accidentalValue, AccidentalValue.natural);
+  });
+
+  test('falls back to other for unrecognized accidental values', () {
+    final unknown = KeyAccidental.parse(
+      XmlDocument.parse('<key-accidental>unknown-value</key-accidental>')
+          .rootElement,
+    );
+    expect(unknown.accidentalValue, AccidentalValue.other);
+  });
+}


### PR DESCRIPTION
Without a default case, unrecognized accidental values cause a LateInitializationError at runtime. Fall back to AccidentalValue.other.
