### PR TITLE
fix: remove duplicate makeTime parse in Grace.parse

### DIFF
--- a/lib/src/element/part/measure/note/grace/grace.dart
+++ b/lib/src/element/part/measure/note/grace/grace.dart
@@ -19,9 +19,6 @@ class Grace extends XmlElement {
     StealTimeFollowing? stealTimeFollowing;
     StealTimePrevious? stealTimePrevious;
     for (final attribute in element.attributes) {
-      if (attribute.name.local == Local.makeTime) {
-        makeTime = MakeTime.parse(attribute);
-      }
       switch (attribute.name.local) {
         case Local.makeTime:
           makeTime = MakeTime.parse(attribute);

--- a/test/assets/grace-element-make-time.xml
+++ b/test/assets/grace-element-make-time.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE score-partwise PUBLIC
+        "-//Recordare//DTD MusicXML 3.0 Partwise//EN"
+        "http://www.musicxml.org/dtds/partwise.dtd">
+<score-partwise version="3.0">
+  <part-list>
+    <score-part id="P1">
+      <part-name>name</part-name>
+    </score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <note>
+        <grace make-time="100" slash="yes"/>
+        <pitch>
+          <step>C</step>
+          <octave>4</octave>
+        </pitch>
+        <voice>1</voice>
+        <type>eighth</type>
+      </note>
+    </measure>
+  </part>
+</score-partwise>

--- a/test/grace_test.dart
+++ b/test/grace_test.dart
@@ -4,15 +4,28 @@ import 'package:music_xml/music_xml.dart';
 import 'package:test/test.dart';
 
 // https://www.w3.org/2021/06/musicxml40/musicxml-reference/examples/grace-element-appoggiatura/
-final asset = File('test/assets/grace-element-appoggiatura.xml');
+final appoggiatura = File('test/assets/grace-element-appoggiatura.xml');
+final makeTimeAsset = File('test/assets/grace-element-make-time.xml');
 
 void main() {
   test('<grace> (Appoggiatura)', () {
-    final document = MusicXmlDocument.parse(asset.readAsStringSync());
+    final document = MusicXmlDocument.parse(appoggiatura.readAsStringSync());
 
     final grace =
         document.score.parts.single.measures.single.notes.single.grace;
     expect(grace!.slash!.yesNo, isFalse);
     expect(grace.stealTimeFollowing!.percent, 33);
+    expect(grace.makeTime, isNull);
+  });
+
+  test('<grace> with make-time', () {
+    final document = MusicXmlDocument.parse(makeTimeAsset.readAsStringSync());
+
+    final grace =
+        document.score.parts.single.measures.single.notes.single.grace;
+    expect(grace!.makeTime!.divisions, 100);
+    expect(grace.slash!.yesNo, isTrue);
+    expect(grace.stealTimeFollowing, isNull);
+    expect(grace.stealTimePrevious, isNull);
   });
 }


### PR DESCRIPTION
The makeTime attribute was parsed twice - once by a leftover if statement and again by the switch case. Added test for make-time.
