### PR TITLE
fix: add return type to Tempo.qpm getter

### DIFF
--- a/lib/src/element/part/measure/direction/sound/tempo.dart
+++ b/lib/src/element/part/measure/direction/sound/tempo.dart
@@ -8,7 +8,7 @@ const defaultQuartersPerMinute = 120.0;
 class Tempo extends XmlAttribute {
   final double nonNegativeDecimal;
 
-  get qpm =>
+  double get qpm =>
       nonNegativeDecimal == 0 ? defaultQuartersPerMinute : nonNegativeDecimal;
 
   /// Parse the MusicXML <sound> element and retrieve the tempo.

--- a/test/assets/tempo-element.xml
+++ b/test/assets/tempo-element.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE score-partwise PUBLIC
+        "-//Recordare//DTD MusicXML 3.0 Partwise//EN"
+        "http://www.musicxml.org/dtds/partwise.dtd">
+<score-partwise version="3.0">
+  <part-list>
+    <score-part id="P1">
+      <part-name>name</part-name>
+    </score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>1</divisions>
+        <time>
+          <beats>4</beats>
+          <beat-type>4</beat-type>
+        </time>
+      </attributes>
+      <direction placement="above">
+        <sound tempo="120"/>
+      </direction>
+      <note>
+        <pitch>
+          <step>C</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>4</duration>
+        <voice>1</voice>
+        <type>whole</type>
+      </note>
+    </measure>
+    <measure number="2">
+      <direction placement="above">
+        <sound tempo="80"/>
+      </direction>
+      <note>
+        <pitch>
+          <step>D</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>4</duration>
+        <voice>1</voice>
+        <type>whole</type>
+      </note>
+    </measure>
+  </part>
+</score-partwise>

--- a/test/tempo_test.dart
+++ b/test/tempo_test.dart
@@ -1,0 +1,31 @@
+import 'dart:io';
+
+import 'package:music_xml/music_xml.dart';
+import 'package:test/test.dart';
+
+final asset = File('test/assets/tempo-element.xml');
+
+void main() {
+  test('Tempo.qpm returns double', () {
+    final document = MusicXmlDocument.parse(asset.readAsStringSync());
+    final measures = document.score.parts.single.measures;
+
+    final tempo1 = measures[0].tempos.first;
+    expect(tempo1.qpm, isA<double>());
+    expect(tempo1.qpm, 120.0);
+
+    final tempo2 = measures[1].tempos.first;
+    expect(tempo2.qpm, isA<double>());
+    expect(tempo2.qpm, 80.0);
+  });
+
+  test('Tempo defaults to 120 when value is 0', () {
+    final tempo = Tempo(0);
+    expect(tempo.qpm, 120.0);
+  });
+
+  test('Tempo.parse defaults to 120 for invalid input', () {
+    final tempo = Tempo.parse('not-a-number');
+    expect(tempo.qpm, 120.0);
+  });
+}


### PR DESCRIPTION
Missing return type caused qpm to return dynamic instead of double. Added tests for Tempo parsing, zero value default, and invalid input.