### PR TITLE
fix: implement _repairEmptyMeasure in Dart

### DIFF
--- a/lib/src/element/part/part.dart
+++ b/lib/src/element/part/part.dart
@@ -108,29 +108,30 @@ class Part extends XmlElement {
       : super(XmlName(Local.part), [id], [...measures]);
 
   /// Repair a measure if it is empty by inserting a whole measure rest.
+  ///
   /// If a <measure> only consists of a <forward> element that advances
   /// the time cursor, remove the <forward> element and replace
   /// with a whole measure rest of the same duration.
   static void _repairEmptyMeasure(XmlElement measure) {
-    final xmlForwards = measure.findElements('forward');
-    final forwardCount = xmlForwards.length;
+    final xmlForwards = measure.findElements('forward').toList();
     final noteCount = measure.findElements('note').length;
-    if (noteCount == 0 && forwardCount == 1) {
-      // Get the duration of the <forward> element
-      // TODO final xmlForward = xmlForwards.single;
-      // final xmlDuration = xmlForward.getElement('duration');
-      // final forwardDuration = int.tryParse(xmlDuration?.text ?? '') ?? 0;
+    if (noteCount == 0 && xmlForwards.length == 1) {
+      final xmlForward = xmlForwards.single;
+      final forwardDuration =
+          xmlForward.getElement('duration')?.innerText ?? '0';
 
-      // # Delete the <forward> element
-      // measure.remove(xml_forward)
-      //
-      // # Insert the new note
-      // new_note = '<note>'
-      // new_note += '<rest /><duration>' + str(forward_duration) + '</duration>'
-      // new_note += '<voice>1</voice><type>whole</type><staff>1</staff>'
-      // new_note += '</note>'
-      // new_note_xml = ET.fromstring(new_note)
-      // measure.append(new_note_xml)
+      xmlForward.parent!.children.remove(xmlForward);
+
+      final restNote = XmlDocument.parse(
+        '<note>'
+        '<rest/>'
+        '<duration>$forwardDuration</duration>'
+        '<voice>1</voice>'
+        '<type>whole</type>'
+        '<staff>1</staff>'
+        '</note>',
+      ).rootElement.copy();
+      measure.children.add(restNote);
     }
   }
 }

--- a/test/assets/empty-measure-forward.xml
+++ b/test/assets/empty-measure-forward.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE score-partwise PUBLIC
+        "-//Recordare//DTD MusicXML 3.0 Partwise//EN"
+        "http://www.musicxml.org/dtds/partwise.dtd">
+<score-partwise version="3.0">
+  <part-list>
+    <score-part id="P1">
+      <part-name>name</part-name>
+    </score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>1</divisions>
+        <time>
+          <beats>4</beats>
+          <beat-type>4</beat-type>
+        </time>
+      </attributes>
+      <forward>
+        <duration>4</duration>
+      </forward>
+    </measure>
+  </part>
+</score-partwise>

--- a/test/repair_empty_measure_test.dart
+++ b/test/repair_empty_measure_test.dart
@@ -1,0 +1,18 @@
+import 'dart:io';
+
+import 'package:music_xml/music_xml.dart';
+import 'package:test/test.dart';
+
+final asset = File('test/assets/empty-measure-forward.xml');
+
+void main() {
+  test('empty measure with only <forward> is repaired to a rest', () {
+    final document = MusicXmlDocument.parse(asset.readAsStringSync());
+
+    final measure = document.score.parts.single.measures.single;
+    expect(measure.notes.length, 1);
+    expect(measure.notes.single.isRest, isTrue);
+    expect(measure.notes.single.noteDuration.duration, 4);
+    expect(measure.notes.single.voice, 1);
+  });
+}


### PR DESCRIPTION
The method body was commented out with leftover Python code from the original Magenta parser. Now properly replaces a <forward>-only measure with a whole measure rest of the same duration.
