### PR TITLE
refactor: consolidate pitch parsing into Pitch object

### DIFF
--- a/lib/src/element/part/measure/note/note.dart
+++ b/lib/src/element/part/measure/note/note.dart
@@ -56,7 +56,6 @@ class Note extends XmlElement {
     final List<Lyric> lyrics = [];
     List<Tie> ties = [];
 
-    MapEntry<String, int>? pitchMap;
     for (final child in xmlNote.childElements) {
       switch (child.name.local) {
         case Local.grace:
@@ -66,7 +65,6 @@ class Note extends XmlElement {
           chord = Chord();
           break;
         case Local.pitch:
-          pitchMap = _parsePitch(child, state);
           pitch = Pitch.parse(child);
           break;
         case Local.unpitched:
@@ -110,6 +108,11 @@ class Note extends XmlElement {
       tupletRatio,
       state,
     );
+
+    final pitchMap = pitch != null
+        ? MapEntry(pitch.toPitchString(),
+            pitch.toMidiPitch(transpose: state.transpose))
+        : null;
 
     return Note(
       grace,
@@ -176,55 +179,6 @@ class Note extends XmlElement {
   /// Returns true if this note is tied to a following note
   bool get isContinuedByOtherNote => !isNoteOff;
 
-  /// Parse the MusicXML <pitch> element.
-  static MapEntry<String, int> _parsePitch(
-    XmlElement xmlPitch,
-    MusicXMLParserState state,
-  ) {
-    final step = xmlPitch.getElement('step')?.innerText ?? '';
-    var alterText = '';
-    var alter = 0.0;
-    final xmlAlter = xmlPitch.getElement('alter');
-    if (xmlAlter != null) alterText = xmlAlter.innerText;
-
-    final octave = xmlPitch.getElement('octave')?.innerText ?? '';
-
-    // Parse alter string to a float (floats represent microtonal alterations)
-    if (alterText.isNotEmpty) alter = double.parse(alterText);
-
-    // Check if this is a semitone alter (i.e. an integer) or microtonal (float)
-    final alterSemitones = alter.toInt(); // Number of semitones
-    final isMicrotonalAlter = (alter != alterSemitones);
-
-    // Visual pitch representation
-    var alterString = '';
-    if (alterSemitones == -2) {
-      alterString = 'bb';
-    } else if (alterSemitones == -1) {
-      alterString = 'b';
-    } else if (alterSemitones == 1) {
-      alterString = '#';
-    } else if (alterSemitones == 2) {
-      alterString = 'x';
-    }
-
-    if (isMicrotonalAlter) alterString += ' (microtones) ';
-
-    // N.B. - pitch_string does not account for transposition
-    final pitchString = '$step$alterString$octave';
-
-    // Compute MIDI pitch number (C4 = 60, C1 = 24, C0 = 12)
-    var midiPitch = pitchToMidiPitch(step, alter, octave);
-    // Transpose MIDI pitch
-    midiPitch += state.transpose;
-    return MapEntry(pitchString, midiPitch);
-  }
-
-  /// Parses a tuplet ratio.
-  ///
-  /// Represented in MusicXML by the <time-modification> element.
-  /// Args:
-  ///   xmlTimeModification: An xml time-modification element.
   static double _parseTuplet(XmlElement xmlTimeModification) {
     final numerator = int.parse(
       xmlTimeModification.getElement('actual-notes')!.innerText,
@@ -234,38 +188,4 @@ class Note extends XmlElement {
     );
     return numerator / denominator;
   }
-}
-
-/// Convert MusicXML pitch representation to MIDI pitch number.
-int pitchToMidiPitch(String step, double alter, String octave) {
-  var pitchClass = 0;
-  switch (step) {
-    case 'C':
-      pitchClass = 0;
-      break;
-    case 'D':
-      pitchClass = 2;
-      break;
-    case 'E':
-      pitchClass = 4;
-      break;
-    case 'F':
-      pitchClass = 5;
-      break;
-    case 'G':
-      pitchClass = 7;
-      break;
-    case 'A':
-      pitchClass = 9;
-      break;
-    case 'B':
-      pitchClass = 11;
-      break;
-    default:
-      // Raise exception for unknown step (ex: 'Q')
-      throw XmlParserException('Unable to parse pitch step $step');
-  }
-
-  pitchClass = (pitchClass + alter.toInt()) % 12;
-  return (12 + pitchClass) + (int.parse(octave) * 12);
 }

--- a/lib/src/element/part/measure/note/pitch/pitch.dart
+++ b/lib/src/element/part/measure/note/pitch/pitch.dart
@@ -4,6 +4,7 @@ import 'alter.dart';
 import 'octave.dart';
 import 'step.dart';
 import '../../../../../local.dart';
+import '../../../../../data_types/step.dart' as dt;
 
 /// https://www.w3.org/2021/06/musicxml40/musicxml-reference/elements/pitch/
 class Pitch extends XmlElement {
@@ -38,4 +39,43 @@ class Pitch extends XmlElement {
           Local.pitch,
           children: [step, if (alter != null) alter, octave],
         );
+
+  static const _stepToPitchClass = {
+    dt.Step.C: 0,
+    dt.Step.D: 2,
+    dt.Step.E: 4,
+    dt.Step.F: 5,
+    dt.Step.G: 7,
+    dt.Step.A: 9,
+    dt.Step.B: 11,
+  };
+
+  /// Compute MIDI pitch number (C4 = 60, C1 = 24, C0 = 12).
+  int toMidiPitch({int transpose = 0}) {
+    final alterValue = alter?.alter ?? 0.0;
+    var pitchClass = (_stepToPitchClass[step.step]! + alterValue.toInt()) % 12;
+    return (12 + pitchClass) + (octave.octave * 12) + transpose;
+  }
+
+  /// Human-readable pitch string like "Bb4", "C#5", "G3".
+  String toPitchString() {
+    final alterValue = alter?.alter ?? 0.0;
+    final alterSemitones = alterValue.toInt();
+    final isMicrotonal = alterValue != alterSemitones;
+
+    var alterStr = '';
+    if (alterSemitones == -2) {
+      alterStr = 'bb';
+    } else if (alterSemitones == -1) {
+      alterStr = 'b';
+    } else if (alterSemitones == 1) {
+      alterStr = '#';
+    } else if (alterSemitones == 2) {
+      alterStr = 'x';
+    }
+    if (isMicrotonal) alterStr += ' (microtones) ';
+
+    final stepStr = step.step.toString().split('.').last;
+    return '$stepStr$alterStr${octave.octave}';
+  }
 }

--- a/test/pitch_test.dart
+++ b/test/pitch_test.dart
@@ -18,6 +18,7 @@ void main() {
     expect(pitch.step.step, dts.Step.G);
     expect(pitch.octave.octave, 3);
   });
+
   test('<alter> (Microtones)', () {
     final document = MusicXmlDocument.parse(alterXml.readAsStringSync());
 
@@ -26,5 +27,44 @@ void main() {
     expect(pitch.step.step, dts.Step.B);
     expect(pitch.alter!.alter, -0.5);
     expect(pitch.octave.octave, 4);
+  });
+
+  test('toMidiPitch computes correct MIDI number', () {
+    final document = MusicXmlDocument.parse(pitchXml.readAsStringSync());
+    final pitch =
+        document.score.parts.single.measures.single.notes.single.pitch!;
+
+    // G3 = 55
+    expect(pitch.toMidiPitch(), 55);
+  });
+
+  test('toMidiPitch with flat alter', () {
+    final document = MusicXmlDocument.parse(
+      File('test/assets/musicXML.xml').readAsStringSync(),
+    );
+    final note = document.score.parts.single.measures.first.notes.last;
+
+    // Bb4 = 70
+    expect(note.pitch!.toMidiPitch(), 70);
+    expect(note.pitchMap?.value, 70);
+  });
+
+  test('toPitchString produces human-readable string', () {
+    final document = MusicXmlDocument.parse(
+      File('test/assets/musicXML.xml').readAsStringSync(),
+    );
+    final note = document.score.parts.single.measures.first.notes.last;
+
+    expect(note.pitch!.toPitchString(), 'Bb4');
+    expect(note.pitchMap?.key, note.pitch!.toPitchString());
+  });
+
+  test('pitchMap is derived from Pitch object', () {
+    final document = MusicXmlDocument.parse(pitchXml.readAsStringSync());
+    final note = document.score.parts.single.measures.single.notes.single;
+
+    expect(note.pitchMap, isNotNull);
+    expect(note.pitchMap!.key, note.pitch!.toPitchString());
+    expect(note.pitchMap!.value, note.pitch!.toMidiPitch());
   });
 }


### PR DESCRIPTION
Remove duplicate _parsePitch and pitchToMidiPitch from Note. Add toMidiPitch() and toPitchString() methods to Pitch, and derive pitchMap from the Pitch object instead of re-parsing XML.
