### PR TITLE
feat: support .mxl compressed MusicXML files (#37)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.7.0
+
+* Support [compressed `.mxl` files](https://www.w3.org/2021/06/musicxml40/tutorial/compressed-mxl-files/) via `MusicXmlDocument.parseMxl(List<int> bytes)` [#37](https://github.com/de-men/music_xml/issues/37)
+* Locates root file via `META-INF/container.xml`; falls back to first `.xml` in the archive
+
 ## 2.6.0
 
 ### New Features

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ A Dart package to parse and serialize [MusicXML 4.0](https://www.w3.org/2021/06/
 ## Features
 
 - Parse MusicXML documents into typed Dart objects
+- Support for both uncompressed `.xml` and [compressed `.mxl`](https://www.w3.org/2021/06/musicxml40/tutorial/compressed-mxl-files/) files
 - All elements extend `XmlElement` for XML roundtripping (parse and serialize)
 - Supports: notes, pitches, unpitched (percussion), grace notes, chords, lyrics, ties, key/time/clef signatures, tempo, dynamics, chord symbols, barlines, and more
 - Follows the [MusicXML 4.0 element hierarchy](https://www.w3.org/2021/06/musicxml40/musicxml-reference/elements/score-partwise/)
@@ -26,7 +27,11 @@ dependencies:
 ```dart
 import 'package:music_xml/music_xml.dart';
 
+// Parse uncompressed XML string
 final document = MusicXmlDocument.parse(xmlString);
+
+// Parse compressed .mxl file bytes
+final mxlDocument = MusicXmlDocument.parseMxl(mxlBytes);
 
 // Access score structure
 final parts = document.score.parts;

--- a/lib/src/music_xml_document.dart
+++ b/lib/src/music_xml_document.dart
@@ -1,12 +1,12 @@
+import 'dart:convert';
+
+import 'package:archive/archive.dart';
 import 'package:music_xml/src/elements/score_partwise.dart';
 import 'package:xml/xml.dart';
 
 /// Internal representation of a MusicXML Document.
-/// Represents the top level object which holds the MusicXML document
-/// Responsible for loading the .xml or .mxl file using the _get_score method
-/// If the file is .mxl, this class uncompresses it
-/// After the file is loaded, this class then parses the document into memory
-/// using the parse method.
+///
+/// Supports both uncompressed `.xml` and compressed `.mxl` input.
 ///
 /// https://www.w3.org/2021/06/musicxml40/musicxml-reference/elements/score-partwise/
 class MusicXmlDocument extends XmlDocument {
@@ -18,7 +18,7 @@ class MusicXmlDocument extends XmlDocument {
   /// Total time in seconds
   double get totalTimeSecs => score.totalTimeSecs;
 
-  /// Parse the uncompressed MusicXML document.
+  /// Parse an uncompressed MusicXML string.
   factory MusicXmlDocument.parse(String input) {
     return MusicXmlDocument.fromXml(XmlDocument.parse(input));
   }
@@ -27,6 +27,48 @@ class MusicXmlDocument extends XmlDocument {
     final scorePartwiseElement = score.getElement('score-partwise')!;
     final scorePartwise = ScorePartwise.parse(scorePartwiseElement);
     return MusicXmlDocument(scorePartwise);
+  }
+
+  /// Parse a compressed `.mxl` file from raw bytes.
+  ///
+  /// An `.mxl` file is a ZIP archive containing one or more MusicXML files.
+  /// The root file is located via `META-INF/container.xml` per the
+  /// [Compressed .MXL Files](https://www.w3.org/2021/06/musicxml40/tutorial/compressed-mxl-files/)
+  /// specification. If `container.xml` is absent, falls back to the first
+  /// `.xml` file in the archive.
+  factory MusicXmlDocument.parseMxl(List<int> bytes) {
+    final archive = ZipDecoder().decodeBytes(bytes);
+    final xmlContent = _extractMusicXml(archive);
+    return MusicXmlDocument.parse(xmlContent);
+  }
+
+  static String _extractMusicXml(Archive archive) {
+    final container = archive.findFile('META-INF/container.xml');
+    if (container != null) {
+      final containerXml =
+          XmlDocument.parse(utf8.decode(container.readBytes()!));
+      final rootFile = containerXml
+          .findAllElements('rootfile')
+          .first
+          .getAttribute('full-path');
+      if (rootFile != null) {
+        final file = archive.findFile(rootFile);
+        if (file != null) {
+          return utf8.decode(file.readBytes()!);
+        }
+      }
+    }
+
+    final xmlFile = archive.files.firstWhere(
+      (f) =>
+          f.name.endsWith('.xml') &&
+          !f.name.startsWith('META-INF/') &&
+          !f.isDirectory,
+      orElse: () => throw FormatException(
+        'No MusicXML file found in .mxl archive',
+      ),
+    );
+    return utf8.decode(xmlFile.readBytes()!);
   }
 
   MusicXmlDocument(this.score) : super([score]);

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -17,6 +17,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "12.0.0"
+  archive:
+    dependency: "direct main"
+    description:
+      name: archive
+      sha256: a96e8b390886ee8abb49b7bd3ac8df6f451c621619f52a26e815fdcf568959ff
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.0.9"
   args:
     dependency: transitive
     description:
@@ -81,6 +89,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.7"
+  ffi:
+    dependency: transitive
+    description:
+      name: ffi
+      sha256: "6d7fd89431262d8f3125e81b50d3847a091d846eafcd4fdb88dd06f36d705a45"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.0"
   file:
     dependency: transitive
     description:
@@ -209,6 +225,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.5.2"
+  posix:
+    dependency: transitive
+    description:
+      name: posix
+      sha256: "185ef7606574f789b40f289c233efa52e96dead518aed988e040a10737febb07"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.5.0"
   pub_semver:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,12 +1,13 @@
 name: music_xml
 description: A Dart package to parse and serialize MusicXML 4.0.
-version: 2.6.0
+version: 2.7.0
 homepage: https://github.com/de-men/music_xml
 
 environment:
   sdk: ">=3.2.0 <4.0.0"
 
 dependencies:
+  archive: ^4.0.9
   xml: ^6.6.1
 
 dev_dependencies:

--- a/test/mxl_test.dart
+++ b/test/mxl_test.dart
@@ -1,0 +1,85 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:archive/archive.dart';
+import 'package:music_xml/music_xml.dart';
+import 'package:test/test.dart';
+
+final xmlFile = File('test/assets/musicXML.xml');
+
+Archive _createMxlArchive(String xmlContent, {bool includeContainer = true}) {
+  final archive = Archive();
+
+  if (includeContainer) {
+    final container = '''<?xml version="1.0" encoding="UTF-8"?>
+<container>
+  <rootfiles>
+    <rootfile full-path="score.xml"/>
+  </rootfiles>
+</container>''';
+    archive.addFile(
+      ArchiveFile.bytes('META-INF/container.xml', utf8.encode(container)),
+    );
+  }
+
+  archive.addFile(ArchiveFile.bytes('score.xml', utf8.encode(xmlContent)));
+  return archive;
+}
+
+void main() {
+  final xmlContent = xmlFile.readAsStringSync();
+  final xmlDocument = MusicXmlDocument.parse(xmlContent);
+
+  group('parseMxl', () {
+    test('parses .mxl with META-INF/container.xml', () {
+      final archive = _createMxlArchive(xmlContent);
+      final mxlBytes = ZipEncoder().encode(archive)!;
+
+      final mxlDocument = MusicXmlDocument.parseMxl(mxlBytes);
+
+      expect(mxlDocument.title, xmlDocument.title);
+      expect(mxlDocument.score.parts.length, xmlDocument.score.parts.length);
+      expect(
+        mxlDocument.score.parts.first.measures.length,
+        xmlDocument.score.parts.first.measures.length,
+      );
+      expect(mxlDocument.totalTimeSecs, closeTo(xmlDocument.totalTimeSecs, 0.1));
+    });
+
+    test('falls back to first .xml file when container.xml is absent', () {
+      final archive = _createMxlArchive(xmlContent, includeContainer: false);
+      final mxlBytes = ZipEncoder().encode(archive)!;
+
+      final mxlDocument = MusicXmlDocument.parseMxl(mxlBytes);
+
+      expect(mxlDocument.title, xmlDocument.title);
+      expect(mxlDocument.score.parts.length, xmlDocument.score.parts.length);
+    });
+
+    test('throws FormatException when archive has no .xml files', () {
+      final archive = Archive();
+      archive.addFile(ArchiveFile.bytes('readme.txt', utf8.encode('hello')));
+      final mxlBytes = ZipEncoder().encode(archive)!;
+
+      expect(
+        () => MusicXmlDocument.parseMxl(mxlBytes),
+        throwsA(isA<FormatException>()),
+      );
+    });
+
+    test('skips META-INF .xml files in fallback', () {
+      final archive = Archive();
+      archive.addFile(
+        ArchiveFile.bytes(
+          'META-INF/other.xml',
+          utf8.encode('<other/>'),
+        ),
+      );
+      archive.addFile(ArchiveFile.bytes('score.xml', utf8.encode(xmlContent)));
+      final mxlBytes = ZipEncoder().encode(archive)!;
+
+      final mxlDocument = MusicXmlDocument.parseMxl(mxlBytes);
+      expect(mxlDocument.title, xmlDocument.title);
+    });
+  });
+}

--- a/test/mxl_test.dart
+++ b/test/mxl_test.dart
@@ -33,7 +33,7 @@ void main() {
   group('parseMxl', () {
     test('parses .mxl with META-INF/container.xml', () {
       final archive = _createMxlArchive(xmlContent);
-      final mxlBytes = ZipEncoder().encode(archive)!;
+      final mxlBytes = ZipEncoder().encode(archive);
 
       final mxlDocument = MusicXmlDocument.parseMxl(mxlBytes);
 
@@ -43,12 +43,13 @@ void main() {
         mxlDocument.score.parts.first.measures.length,
         xmlDocument.score.parts.first.measures.length,
       );
-      expect(mxlDocument.totalTimeSecs, closeTo(xmlDocument.totalTimeSecs, 0.1));
+      expect(
+          mxlDocument.totalTimeSecs, closeTo(xmlDocument.totalTimeSecs, 0.1));
     });
 
     test('falls back to first .xml file when container.xml is absent', () {
       final archive = _createMxlArchive(xmlContent, includeContainer: false);
-      final mxlBytes = ZipEncoder().encode(archive)!;
+      final mxlBytes = ZipEncoder().encode(archive);
 
       final mxlDocument = MusicXmlDocument.parseMxl(mxlBytes);
 
@@ -59,7 +60,7 @@ void main() {
     test('throws FormatException when archive has no .xml files', () {
       final archive = Archive();
       archive.addFile(ArchiveFile.bytes('readme.txt', utf8.encode('hello')));
-      final mxlBytes = ZipEncoder().encode(archive)!;
+      final mxlBytes = ZipEncoder().encode(archive);
 
       expect(
         () => MusicXmlDocument.parseMxl(mxlBytes),
@@ -76,7 +77,7 @@ void main() {
         ),
       );
       archive.addFile(ArchiveFile.bytes('score.xml', utf8.encode(xmlContent)));
-      final mxlBytes = ZipEncoder().encode(archive)!;
+      final mxlBytes = ZipEncoder().encode(archive);
 
       final mxlDocument = MusicXmlDocument.parseMxl(mxlBytes);
       expect(mxlDocument.title, xmlDocument.title);


### PR DESCRIPTION
Add MusicXmlDocument.parseMxl(List<int> bytes) to parse compressed .mxl archives. Locates root file via META-INF/container.xml per the MusicXML spec, with fallback to the first .xml file in the archive.
