### PR TITLE
feat: support <type> element on notes (#53)

### DIFF
--- a/lib/music_xml.dart
+++ b/lib/music_xml.dart
@@ -18,3 +18,6 @@ export 'src/elements/partlist/scorepart/score_part.dart';
 export 'src/attributes/tempo.dart';
 export 'src/elements/part/measure/attributes/time/time.dart';
 export 'src/elements/part/measure/note/tie.dart';
+export 'src/elements/part/measure/note/note_type.dart';
+export 'src/data_types/note_type_value.dart';
+export 'src/data_types/symbol_size.dart';

--- a/lib/src/data_types/note_type_value.dart
+++ b/lib/src/data_types/note_type_value.dart
@@ -1,0 +1,59 @@
+/// https://www.w3.org/2021/06/musicxml40/musicxml-reference/data-types/note-type-value/
+///
+/// The graphic note type, from `1024th` (shortest) to `maxima` (longest).
+/// Names that start with a digit in MusicXML get an `n` prefix here, since
+/// Dart identifiers can not start with a digit.
+enum NoteTypeValue {
+  n1024th,
+  n512th,
+  n256th,
+  n128th,
+  n64th,
+  n32nd,
+  n16th,
+  eighth,
+  quarter,
+  half,
+  whole,
+  breve,
+  long,
+  maxima,
+}
+
+const _noteTypeValueMap = {
+  '1024th': NoteTypeValue.n1024th,
+  '512th': NoteTypeValue.n512th,
+  '256th': NoteTypeValue.n256th,
+  '128th': NoteTypeValue.n128th,
+  '64th': NoteTypeValue.n64th,
+  '32nd': NoteTypeValue.n32nd,
+  '16th': NoteTypeValue.n16th,
+  'eighth': NoteTypeValue.eighth,
+  'quarter': NoteTypeValue.quarter,
+  'half': NoteTypeValue.half,
+  'whole': NoteTypeValue.whole,
+  'breve': NoteTypeValue.breve,
+  'long': NoteTypeValue.long,
+  'maxima': NoteTypeValue.maxima,
+};
+
+/// Returns the enum for a MusicXML value, or null when the value is not one
+/// of the standard note types (some exporters write non-standard values).
+NoteTypeValue? parseNoteTypeValue(String str) => _noteTypeValueMap[str];
+
+const noteTypeValueToString = {
+  NoteTypeValue.n1024th: '1024th',
+  NoteTypeValue.n512th: '512th',
+  NoteTypeValue.n256th: '256th',
+  NoteTypeValue.n128th: '128th',
+  NoteTypeValue.n64th: '64th',
+  NoteTypeValue.n32nd: '32nd',
+  NoteTypeValue.n16th: '16th',
+  NoteTypeValue.eighth: 'eighth',
+  NoteTypeValue.quarter: 'quarter',
+  NoteTypeValue.half: 'half',
+  NoteTypeValue.whole: 'whole',
+  NoteTypeValue.breve: 'breve',
+  NoteTypeValue.long: 'long',
+  NoteTypeValue.maxima: 'maxima',
+};

--- a/lib/src/data_types/symbol_size.dart
+++ b/lib/src/data_types/symbol_size.dart
@@ -1,0 +1,40 @@
+import 'package:xml/xml.dart';
+
+import '../local.dart';
+
+/// https://www.w3.org/2021/06/musicxml40/musicxml-reference/data-types/symbol-size/
+///
+/// Tells apart full, cue, grace-cue, and large symbols. Used by the `size`
+/// attribute of `<type>`, `<accidental>`, `<clef>`, and `<level>`.
+enum SymbolSize {
+  cue,
+  full,
+  graceCue,
+  large,
+}
+
+const _symbolSizeMap = {
+  'cue': SymbolSize.cue,
+  'full': SymbolSize.full,
+  'grace-cue': SymbolSize.graceCue,
+  'large': SymbolSize.large,
+};
+
+/// Returns the enum for a MusicXML value, or null when the value is not one
+/// of the standard symbol sizes.
+SymbolSize? parseSymbolSize(String str) => _symbolSizeMap[str];
+
+const symbolSizeToString = {
+  SymbolSize.cue: 'cue',
+  SymbolSize.full: 'full',
+  SymbolSize.graceCue: 'grace-cue',
+  SymbolSize.large: 'large',
+};
+
+/// The `size` attribute (symbol-size) shared by several elements.
+class SymbolSizeAttr extends XmlAttribute {
+  final SymbolSize symbolSize;
+
+  SymbolSizeAttr(this.symbolSize)
+      : super(XmlName(Local.size), symbolSizeToString[symbolSize]!);
+}

--- a/lib/src/elements/part/measure/note/note.dart
+++ b/lib/src/elements/part/measure/note/note.dart
@@ -7,6 +7,7 @@ import 'chord.dart';
 import 'dot.dart';
 import 'grace.dart';
 import 'notations/notations.dart';
+import 'note_type.dart';
 import 'pitch/pitch.dart';
 import '../duration.dart' as music_xml;
 import 'rest.dart';
@@ -48,6 +49,10 @@ class Note extends XmlElement {
   final int velocity;
   final NoteDuration noteDuration;
 
+  /// The `<type>` element from the source, or null when it was missing.
+  /// Kept so serialization does not add a `<type>` that was not there.
+  final NoteType? type;
+
   bool get isRest => rest != null;
 
   /// Tied notes will have the same note id.
@@ -74,7 +79,7 @@ class Note extends XmlElement {
     Rest? rest;
     music_xml.Duration? duration;
     final dots = <Dot>[];
-    String? type;
+    NoteType? type;
     double? tupletRatio;
 
     final List<Beam> beams = [];
@@ -112,7 +117,7 @@ class Note extends XmlElement {
           dots.add(Dot.parse(child));
           break;
         case Local.type:
-          type = child.innerText;
+          type = NoteType.parse(child);
           break;
         case Local.timeModification:
           tupletRatio = _parseTuplet(child);
@@ -145,7 +150,7 @@ class Note extends XmlElement {
       grace != null,
       duration?.positiveDivisions,
       dots.length,
-      type,
+      type?.content,
       tupletRatio,
       state,
     );
@@ -176,6 +181,7 @@ class Note extends XmlElement {
       pitchMap,
       lyrics.isNotEmpty ? lyrics : null,
       ties,
+      type,
     );
   }
 
@@ -200,6 +206,7 @@ class Note extends XmlElement {
     this.pitchMap,
     this.lyrics,
     this.ties,
+    this.type,
   ) : super.tag(
           Local.note,
           children: [
@@ -210,6 +217,7 @@ class Note extends XmlElement {
             if (rest != null) rest,
             if (duration != null) duration,
             if (voice != null) voice,
+            if (type != null) type,
             ...dots,
             ...beams,
             if (stem != null) stem,

--- a/lib/src/elements/part/measure/note/note_type.dart
+++ b/lib/src/elements/part/measure/note/note_type.dart
@@ -1,0 +1,42 @@
+import 'package:xml/xml.dart';
+
+import '../../../../data_types/note_type_value.dart';
+import '../../../../data_types/symbol_size.dart';
+import '../../../../local.dart';
+
+/// The MusicXML `<type>` element inside a `<note>`.
+/// It holds the graphic note type, such as `whole`, `half`, or `quarter`.
+/// https://www.w3.org/2021/06/musicxml40/musicxml-reference/elements/type/
+class NoteType extends XmlElement {
+  /// The raw text value, kept as-is so any value round-trips (even
+  /// non-standard ones some exporters write, like `dotted-half`).
+  final String content;
+
+  /// The `size` attribute (symbol-size), or null when it was missing.
+  final SymbolSize? size;
+
+  /// The typed note type value, or null when [content] is not a standard
+  /// MusicXML note type.
+  NoteTypeValue? get noteTypeValue => parseNoteTypeValue(content);
+
+  factory NoteType.parse(XmlElement element) {
+    final sizeAttr = element.getAttribute(Local.size);
+    return NoteType(
+      element.innerText,
+      size: sizeAttr != null ? parseSymbolSize(sizeAttr) : null,
+    );
+  }
+
+  NoteType(this.content, {this.size})
+      : super.tag(
+          Local.type,
+          attributes: [
+            if (size != null) SymbolSizeAttr(size),
+          ],
+          children: [XmlText(content)],
+        );
+
+  /// Builds a `<type>` from a typed value.
+  NoteType.of(NoteTypeValue value, {SymbolSize? size})
+      : this(noteTypeValueToString[value]!, size: size);
+}

--- a/lib/src/local.dart
+++ b/lib/src/local.dart
@@ -9,6 +9,7 @@ class Local {
   static const xlinkTitle = 'xlink:title';
   static const xlinkType = 'xlink:type';
   static const type = 'type';
+  static const size = 'size';
   static const name = 'name';
   static const element = 'element';
   static const attribute = 'attribute';

--- a/test/assets/accent-element.xml
+++ b/test/assets/accent-element.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 4.0 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">
+<score-partwise version="4.0">
+  <part-list>
+    <score-part id="P1">
+      <part-name>Music</part-name>
+    </score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>1</divisions>
+      </attributes>
+      <note default-x="36">
+        <pitch>
+          <step>A</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>4</duration>
+        <voice>1</voice>
+        <type>half</type>
+        <stem default-y="10">up</stem>
+        <notations>
+          <articulations>
+            <accent default-x="-1" default-y="-55" placement="below"/>
+          </articulations>
+        </notations>
+      </note>
+    </measure>
+  </part>
+</score-partwise>

--- a/test/note_type_test.dart
+++ b/test/note_type_test.dart
@@ -1,0 +1,127 @@
+import 'dart:io';
+
+import 'package:music_xml/music_xml.dart';
+import 'package:test/test.dart';
+import 'package:xml/xml.dart';
+
+// https://github.com/de-men/music_xml/issues/53
+// <type> must survive parse -> toXmlString() -> parse.
+const _wholeNote = '''
+<score-partwise version="4.0">
+  <part-list>
+    <score-part id="P1">
+      <part-name>Music</part-name>
+    </score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>1</divisions>
+      </attributes>
+      <note>
+        <pitch>
+          <step>C</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>4</duration>
+        <type>whole</type>
+      </note>
+    </measure>
+  </part>
+</score-partwise>''';
+
+const _restNoType = '''
+<score-partwise version="4.0">
+  <part-list>
+    <score-part id="P1">
+      <part-name>Music</part-name>
+    </score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>1</divisions>
+      </attributes>
+      <note>
+        <rest/>
+        <duration>4</duration>
+      </note>
+    </measure>
+  </part>
+</score-partwise>''';
+
+void main() {
+  test('<type> is kept after toXmlString()', () {
+    final doc = MusicXmlDocument.parse(_wholeNote);
+    final note = doc.score.parts.first.measures.first.notes.first;
+    expect(note.noteDuration.type, 'whole');
+    expect(note.type?.noteTypeValue, NoteTypeValue.whole);
+
+    final xml = doc.toXmlString();
+    expect(xml, contains('<type>whole</type>'));
+
+    final reparsed = MusicXmlDocument.parse(xml);
+    final reparsedNote = reparsed.score.parts.first.measures.first.notes.first;
+    expect(reparsedNote.noteDuration.type, 'whole');
+  });
+
+  // https://www.w3.org/2021/06/musicxml40/musicxml-reference/examples/accent-element/
+  test('official <accent> example keeps <type>half</type> on round-trip', () {
+    final accentAsset = File('test/assets/accent-element.xml');
+    final doc = MusicXmlDocument.parse(accentAsset.readAsStringSync());
+    final note = doc.score.parts.first.measures.first.notes.first;
+    expect(note.type?.noteTypeValue, NoteTypeValue.half);
+    expect(note.noteDuration.type, 'half');
+
+    final xml = doc.toXmlString();
+    expect(xml, contains('<type>half</type>'));
+
+    final reparsed = MusicXmlDocument.parse(xml);
+    final reparsedNote = reparsed.score.parts.first.measures.first.notes.first;
+    expect(reparsedNote.type?.noteTypeValue, NoteTypeValue.half);
+    expect(reparsedNote.noteDuration.type, 'half');
+  });
+
+  test('a note without <type> stays without <type>', () {
+    final doc = MusicXmlDocument.parse(_restNoType);
+    final note = doc.score.parts.first.measures.first.notes.first;
+    expect(note.type, isNull);
+    // default stays 'quarter' in NoteDuration, but no tag is written.
+    expect(note.noteDuration.type, 'quarter');
+
+    final xml = doc.toXmlString();
+    expect(xml.contains('<type>'), isFalse);
+  });
+
+  test('digit-prefixed values map both ways', () {
+    expect(parseNoteTypeValue('16th'), NoteTypeValue.n16th);
+    expect(parseNoteTypeValue('1024th'), NoteTypeValue.n1024th);
+    expect(noteTypeValueToString[NoteTypeValue.n16th], '16th');
+    expect(NoteType.of(NoteTypeValue.n16th).toXmlString(), '<type>16th</type>');
+  });
+
+  test('non-standard <type> value round-trips and gives null enum', () {
+    final noteType = NoteType('dotted-half');
+    expect(noteType.noteTypeValue, isNull);
+    expect(noteType.toXmlString(), '<type>dotted-half</type>');
+    expect(parseNoteTypeValue('dotted-half'), isNull);
+  });
+
+  test('size attribute is parsed and serialized', () {
+    final parsed = NoteType.parse(
+        XmlDocument.parse('<type size="cue">half</type>').rootElement);
+    expect(parsed.noteTypeValue, NoteTypeValue.half);
+    expect(parsed.size, SymbolSize.cue);
+    expect(parsed.toXmlString(), '<type size="cue">half</type>');
+
+    expect(
+      NoteType.of(NoteTypeValue.eighth, size: SymbolSize.large).toXmlString(),
+      '<type size="large">eighth</type>',
+    );
+  });
+
+  test('grace-cue size maps both ways', () {
+    expect(parseSymbolSize('grace-cue'), SymbolSize.graceCue);
+    expect(symbolSizeToString[SymbolSize.graceCue], 'grace-cue');
+  });
+}


### PR DESCRIPTION
Before, <type> was parsed but never written back, so toXmlString() dropped it and re-parsing fell back to 'quarter'. Add a NoteType element that keeps the raw text (round-trips any value, even non-standard ones), plus a NoteTypeValue enum and the size attribute (symbol-size).