### PR TITLE
feat: support cautionary and editorial attributes on <accidental> (#52)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+* [`<accidental>`](https://www.w3.org/2021/06/musicxml40/musicxml-reference/elements/accidental/) now supports the `cautionary` and `editorial` yes/no attributes [#52](https://github.com/de-men/music_xml/issues/52)
+
 ## 2.7.0
 
 * Support [compressed `.mxl` files](https://www.w3.org/2021/06/musicxml40/tutorial/compressed-mxl-files/) via `MusicXmlDocument.parseMxl(List<int> bytes)` [#37](https://github.com/de-men/music_xml/issues/37)

--- a/lib/src/elements/part/measure/note/accidental.dart
+++ b/lib/src/elements/part/measure/note/accidental.dart
@@ -1,22 +1,40 @@
 import 'package:xml/xml.dart';
 
+import '../../../../attributes/yes_no_attribute.dart';
+import '../../../../basic_attributes.dart';
 import '../../../../data_types/accidental_value.dart';
 import '../../../../local.dart';
 
 /// https://www.w3.org/2021/06/musicxml40/musicxml-reference/elements/accidental/
 class Accidental extends XmlElement {
-  // TODO: support attributes: bracket, cautionary, color, default-x,
-  //       default-y, editorial, font-family, font-size, font-style,
+  // TODO: support attributes: bracket, color, default-x,
+  //       default-y, font-family, font-size, font-style,
   //       font-weight, parentheses, relative-x, relative-y, size, smufl
   final AccidentalValue accidentalValue;
 
+  /// `cautionary="yes"` shows the accidental in parentheses.
+  final bool? cautionary;
+
+  /// `editorial="yes"` shows the accidental as an editorial mark.
+  final bool? editorial;
+
   factory Accidental.parse(XmlElement element) {
-    return Accidental(parseAccidentalValue(element.innerText));
+    final cautionaryAttr = element.getAttribute(Local.cautionary);
+    final editorialAttr = element.getAttribute(Local.editorial);
+    return Accidental(
+      parseAccidentalValue(element.innerText),
+      cautionary: cautionaryAttr != null ? parseYesNo(cautionaryAttr) : null,
+      editorial: editorialAttr != null ? parseYesNo(editorialAttr) : null,
+    );
   }
 
-  Accidental(this.accidentalValue)
+  Accidental(this.accidentalValue, {this.cautionary, this.editorial})
       : super.tag(
           Local.accidental,
+          attributes: [
+            if (cautionary != null) YesNoAttr(Local.cautionary, cautionary),
+            if (editorial != null) YesNoAttr(Local.editorial, editorial),
+          ],
           children: [XmlText(accidentalValueToString[accidentalValue]!)],
         );
 }

--- a/lib/src/local.dart
+++ b/lib/src/local.dart
@@ -116,6 +116,8 @@ class Local {
   static const displayText = 'display-text';
   static const accidentalText = 'accidental-text';
   static const printObject = 'print-object';
+  static const cautionary = 'cautionary';
+  static const editorial = 'editorial';
   static const footnote = 'footnote';
   static const level = 'level';
   static const groupSymbol = 'group-symbol';

--- a/test/assets/accidental-element-cautionary-editorial.xml
+++ b/test/assets/accidental-element-cautionary-editorial.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 4.0 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">
+<score-partwise version="4.0">
+  <part-list>
+    <score-part id="P1">
+      <part-name>Piano</part-name>
+    </score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>1</divisions>
+      </attributes>
+      <note>
+        <pitch>
+          <step>C</step>
+          <alter>1</alter>
+          <octave>5</octave>
+        </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <accidental>sharp</accidental>
+      </note>
+      <note>
+        <pitch>
+          <step>C</step>
+          <alter>1</alter>
+          <octave>5</octave>
+        </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <accidental cautionary="yes">sharp</accidental>
+      </note>
+      <note>
+        <pitch>
+          <step>C</step>
+          <alter>1</alter>
+          <octave>5</octave>
+        </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <accidental editorial="yes">sharp</accidental>
+      </note>
+    </measure>
+  </part>
+</score-partwise>

--- a/test/note_children_test.dart
+++ b/test/note_children_test.dart
@@ -88,4 +88,34 @@ void main() {
     expect(notes[1].accidental, isA<Accidental>());
     expect(notes[1].accidental!.accidentalValue, AccidentalValue.sharp);
   });
+
+  // https://github.com/de-men/music_xml/issues/52
+  test('<accidental> cautionary and editorial attributes', () {
+    final accidentalAsset =
+        File('test/assets/accidental-element-cautionary-editorial.xml');
+    final doc = MusicXmlDocument.parse(accidentalAsset.readAsStringSync());
+    final accidentalNotes = doc.score.parts.first.measures.first.notes;
+
+    // Plain accidental: both attributes are absent.
+    expect(accidentalNotes[0].accidental!.cautionary, isNull);
+    expect(accidentalNotes[0].accidental!.editorial, isNull);
+
+    // cautionary="yes"
+    expect(accidentalNotes[1].accidental!.cautionary, isTrue);
+    expect(accidentalNotes[1].accidental!.editorial, isNull);
+
+    // editorial="yes"
+    expect(accidentalNotes[2].accidental!.editorial, isTrue);
+    expect(accidentalNotes[2].accidental!.cautionary, isNull);
+
+    // Round-trip: the attributes are written back to XML.
+    expect(
+      accidentalNotes[1].accidental!.toXmlString(),
+      '<accidental cautionary="yes">sharp</accidental>',
+    );
+    expect(
+      accidentalNotes[2].accidental!.toXmlString(),
+      '<accidental editorial="yes">sharp</accidental>',
+    );
+  });
 }


### PR DESCRIPTION
The <accidental> element can carry cautionary="yes" and editorial="yes". Before, both were dropped on parse and on write-back. Add two bool? fields and round-trip them as YesNoAttr, following the Rest pattern.