### PR TITLE
fix: keep <tie> in serialized <note> children (#60)

### DIFF
--- a/lib/src/elements/part/measure/note/note.dart
+++ b/lib/src/elements/part/measure/note/note.dart
@@ -218,6 +218,7 @@ class Note extends XmlElement {
           if (unpitched != null) unpitched,
           if (rest != null) rest,
           if (duration != null) duration,
+          ...ties,
           if (voice != null) voice,
           if (type != null) type,
           ...dots,

--- a/test/tied_test.dart
+++ b/test/tied_test.dart
@@ -4,10 +4,15 @@ import 'package:music_xml/music_xml.dart';
 import 'package:music_xml/src/data_types/stem_value.dart';
 import 'package:music_xml/src/data_types/tied_type.dart';
 import 'package:music_xml/src/elements/part/measure/note/stem.dart';
+import 'package:music_xml/src/local.dart';
 import 'package:test/test.dart';
+import 'package:xml/xml.dart';
 
 // https://www.w3.org/2021/06/musicxml40/musicxml-reference/examples/tied-element/
 final asset = File('test/assets/tied-element.xml');
+
+List<String> childNames(XmlElement element) =>
+    element.childElements.map((e) => e.name.local).toList();
 
 void main() {
   late List<Note> notes;
@@ -61,5 +66,40 @@ void main() {
     expect(notes[2].ties, isEmpty);
     expect(notes[3].notations, isEmpty);
     expect(notes[3].ties, isEmpty);
+  });
+
+  // https://github.com/de-men/music_xml/issues/60
+  test('<tie> and <tied> survive a round trip', () {
+    final output = MusicXmlDocument.parse(
+      asset.readAsStringSync(),
+    ).toXmlString();
+
+    expect('<tie '.allMatches(output).length, 2);
+    expect('<tied '.allMatches(output).length, 3);
+  });
+
+  test('<tie> is written between <duration> and <voice>', () {
+    expect(childNames(notes[0]), [
+      'pitch',
+      'duration',
+      'tie',
+      'voice',
+      'type',
+      'stem',
+      'notations',
+    ]);
+  });
+
+  test('every <note> keeps the children it was parsed from', () {
+    final source = asset.readAsStringSync();
+
+    List<List<String>> noteShapes(String xml) => XmlDocument.parse(
+      xml,
+    ).findAllElements(Local.note).map(childNames).toList();
+
+    expect(
+      noteShapes(MusicXmlDocument.parse(source).toXmlString()),
+      noteShapes(source),
+    );
   });
 }


### PR DESCRIPTION
Closes #60. Replaces #61.

## Problem

The `<note>` constructor built its child list without the parsed ties, so every `<tie>` was dropped on serialization. Parse a file and write it back, and the tie information was gone.

`<tied>` inside `<notations>` was never broken on its own — it disappeared for the same reason, because the parent `<note>` never carried the tie into its children at all.

## Fix

One line: add `...ties` to the child list, in the slot the MusicXML content model gives it, between `<duration>` and `<voice>`.

## Credit

@SheepYang1993 found this in #60 and wrote the same one-line fix in #61. That PR also added a `syncChildrenToXml()` layer that re-appended the ties at serialize time, which moved `<tie>` after `<stem>` and broke the spec order, so this PR keeps only the constructor change. Thank you for the report and the fix.

## Test plan

- [x] `dart test` — 113 pass (3 new)
- [x] `dart analyze` — clean
- [x] `dart format` — no changes
- [x] All 3 new tests fail on `main` and pass here