### PR TITLE
fix: order <note> children to match the MusicXML content model

### DIFF
--- a/lib/src/elements/part/measure/note/note.dart
+++ b/lib/src/elements/part/measure/note/note.dart
@@ -211,6 +211,8 @@ class Note extends XmlElement {
     this.type,
   ) : super.tag(
         Local.note,
+        // The MusicXML content model for <note> is a fixed sequence, so a
+        // child written in the wrong slot makes the document fail validation.
         children: [
           if (grace != null) grace,
           if (chord != null) chord,
@@ -222,10 +224,10 @@ class Note extends XmlElement {
           if (voice != null) voice,
           if (type != null) type,
           ...dots,
-          ...beams,
+          if (accidental != null) accidental,
           if (stem != null) stem,
           if (staff != null) staff,
-          if (accidental != null) accidental,
+          ...beams,
           ...notations,
         ],
       );

--- a/lib/src/elements/part/measure/note/note.dart
+++ b/lib/src/elements/part/measure/note/note.dart
@@ -218,6 +218,7 @@ class Note extends XmlElement {
           if (unpitched != null) unpitched,
           if (rest != null) rest,
           if (duration != null) duration,
+          ...ties,
           if (voice != null) voice,
           if (type != null) type,
           ...dots,

--- a/test/note_children_test.dart
+++ b/test/note_children_test.dart
@@ -8,9 +8,30 @@ import 'package:music_xml/src/elements/part/measure/note/accidental.dart';
 import 'package:music_xml/src/elements/part/measure/note/beam.dart';
 import 'package:music_xml/src/elements/part/measure/note/staff.dart';
 import 'package:music_xml/src/elements/part/measure/note/stem.dart';
+import 'package:music_xml/src/local.dart';
 import 'package:test/test.dart';
+import 'package:xml/xml.dart';
 
 final asset = File('test/assets/notations-element.xml');
+
+List<String> childNames(XmlElement element) =>
+    element.childElements.map((e) => e.name.local).toList();
+
+/// `<note>` children that [Note] still drops when it writes itself back out.
+/// `<time-modification>` and `<lyric>` are parsed but never serialized; the
+/// rest are not parsed at all. Remove a name here once it round-trips.
+const unwrittenChildren = {
+  Local.timeModification,
+  Local.lyric,
+  'cue',
+  'instrument',
+  'footnote',
+  'level',
+  'notehead',
+  'notehead-text',
+  'play',
+  'listen',
+};
 
 void main() {
   late List<Note> notes;
@@ -119,4 +140,43 @@ void main() {
       '<accidental editorial="yes">sharp</accidental>',
     );
   });
+
+  // The MusicXML content model puts <accidental> before <stem> and <beam>
+  // after <staff>. https://www.w3.org/2021/06/musicxml40/musicxml-reference/elements/note/
+  test('<note> children are serialized in spec order', () {
+    expect(childNames(notes[1]), [
+      'pitch',
+      'duration',
+      'type',
+      'accidental',
+      'stem',
+      'staff',
+      'beam',
+      'notations',
+    ]);
+  });
+
+  for (final name in const [
+    'notations-element',
+    'beam-element',
+    'staff-element',
+  ]) {
+    test('$name.xml keeps every supported <note> child on a round trip', () {
+      final source = File('test/assets/$name.xml').readAsStringSync();
+
+      List<List<String>> noteShapes(String xml) => XmlDocument.parse(xml)
+          .findAllElements(Local.note)
+          .map(
+            (note) => childNames(
+              note,
+            ).where((c) => !unwrittenChildren.contains(c)).toList(),
+          )
+          .toList();
+
+      expect(
+        noteShapes(MusicXmlDocument.parse(source).toXmlString()),
+        noteShapes(source),
+      );
+    });
+  }
 }

--- a/test/tied_test.dart
+++ b/test/tied_test.dart
@@ -4,10 +4,15 @@ import 'package:music_xml/music_xml.dart';
 import 'package:music_xml/src/data_types/stem_value.dart';
 import 'package:music_xml/src/data_types/tied_type.dart';
 import 'package:music_xml/src/elements/part/measure/note/stem.dart';
+import 'package:music_xml/src/local.dart';
 import 'package:test/test.dart';
+import 'package:xml/xml.dart';
 
 // https://www.w3.org/2021/06/musicxml40/musicxml-reference/examples/tied-element/
 final asset = File('test/assets/tied-element.xml');
+
+List<String> childNames(XmlElement element) =>
+    element.childElements.map((e) => e.name.local).toList();
 
 void main() {
   late List<Note> notes;
@@ -61,5 +66,40 @@ void main() {
     expect(notes[2].ties, isEmpty);
     expect(notes[3].notations, isEmpty);
     expect(notes[3].ties, isEmpty);
+  });
+
+  // https://github.com/de-men/music_xml/issues/60
+  test('<tie> and <tied> survive a round trip', () {
+    final output = MusicXmlDocument.parse(
+      asset.readAsStringSync(),
+    ).toXmlString();
+
+    expect('<tie '.allMatches(output).length, 2);
+    expect('<tied '.allMatches(output).length, 3);
+  });
+
+  test('<tie> is written between <duration> and <voice>', () {
+    expect(childNames(notes[0]), [
+      'pitch',
+      'duration',
+      'tie',
+      'voice',
+      'type',
+      'stem',
+      'notations',
+    ]);
+  });
+
+  test('every <note> keeps the children it was parsed from', () {
+    final source = asset.readAsStringSync();
+
+    List<List<String>> noteShapes(String xml) => XmlDocument.parse(
+      xml,
+    ).findAllElements(Local.note).map(childNames).toList();
+
+    expect(
+      noteShapes(MusicXmlDocument.parse(source).toXmlString()),
+      noteShapes(source),
+    );
   });
 }


### PR DESCRIPTION
Stacked on #62 — review that one first. Base will switch to `main` once #62 merges.

## Problem

Pre-existing on `main`, unrelated to #60. The `<note>` child list writes `<beam>` before `<stem>`, and `<accidental>` after `<staff>`. The spec sequence is `<accidental>`, `<stem>`, `<staff>`, `<beam>`.

Nothing is lost, but the output fails schema validation, so other tools may reject the file or drop elements.

## Fix

Move the two entries into their spec slots, and add a round-trip test per asset that compares every `<note>` child list against the source file.

The children the library still drops are listed explicitly in `unwrittenChildren` rather than being silently ignored, so the remaining gap stays visible. Today that is `<time-modification>` and `<lyric>` (parsed but never written), plus the ones that are never parsed.

## Known, not fixed here

`<measure>` has a worse version of the same problem: it groups children by type, so `<backup>` moves after all the notes. On `voice-element.xml` that turns two parallel voices into eight notes in a row. That needs the source order preserved, not a fixed order, so it belongs in its own change.

## Test plan

- [x] `dart test` — 117 pass (4 new)
- [x] `dart analyze` — clean
- [x] `dart format` — no changes
- [x] All 4 new tests fail without the fix